### PR TITLE
darwin pf support

### DIFF
--- a/common/redir/redir_darwin.go
+++ b/common/redir/redir_darwin.go
@@ -1,0 +1,64 @@
+package redir
+
+import (
+	"net"
+	"net/netip"
+	"syscall"
+	"unsafe"
+
+	M "github.com/sagernet/sing/common/metadata"
+)
+
+const (
+	PF_OUT      = 0x2
+	DIOCNATLOOK = 0xc0544417
+)
+
+func GetOriginalDestination(conn net.Conn) (destination netip.AddrPort, err error) {
+	fd, err := syscall.Open("/dev/pf", 0, syscall.O_RDONLY)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	defer syscall.Close(fd)
+	nl := struct {
+		saddr, daddr, rsaddr, rdaddr       [16]byte
+		sxport, dxport, rsxport, rdxport   [4]byte
+		af, proto, protoVariant, direction uint8
+	}{
+		af:        syscall.AF_INET,
+		proto:     syscall.IPPROTO_TCP,
+		direction: PF_OUT,
+	}
+	la := conn.LocalAddr().(*net.TCPAddr)
+	ra := conn.RemoteAddr().(*net.TCPAddr)
+	raIP, laIP := ra.IP, la.IP
+	raPort, laPort := ra.Port, la.Port
+	switch {
+	case raIP.To4() != nil:
+		copy(nl.saddr[:net.IPv4len], raIP.To4())
+		copy(nl.daddr[:net.IPv4len], laIP.To4())
+		nl.af = syscall.AF_INET
+	default:
+		copy(nl.saddr[:], raIP.To16())
+		copy(nl.daddr[:], laIP.To16())
+		nl.af = syscall.AF_INET6
+	}
+	nl.sxport[0], nl.sxport[1] = byte(raPort>>8), byte(raPort)
+	nl.dxport[0], nl.dxport[1] = byte(laPort>>8), byte(laPort)
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), DIOCNATLOOK, uintptr(unsafe.Pointer(&nl))); errno != 0 {
+		return netip.AddrPort{}, errno
+	}
+
+	var ip net.IP
+	switch nl.af {
+	case syscall.AF_INET:
+		ip = make(net.IP, net.IPv4len)
+		copy(ip, nl.rdaddr[:net.IPv4len])
+	case syscall.AF_INET6:
+		ip = make(net.IP, net.IPv6len)
+		copy(ip, nl.rdaddr[:])
+	}
+	port := uint16(nl.rdxport[0])<<8 | uint16(nl.rdxport[1])
+	destination = netip.AddrPortFrom(M.AddrFromIP(ip), port)
+	return
+}

--- a/common/redir/redir_other.go
+++ b/common/redir/redir_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package redir
 


### PR DESCRIPTION
example:

/etc/pf.conf
```
scrub-anchor "com.apple/*"

table <direct_cidr> persist file "/path/to/direct_cidr.txt"

nat-anchor "com.apple/*"

rdr-anchor "com.apple/*"
rdr pass on lo0 proto tcp from any to !<direct_cidr> -> 127.0.0.1 port 12345
rdr pass on lo0 proto tcp from any to !<direct_cidr> -> ::1 port 12345

pass out route-to (lo0 127.0.0.1) proto tcp from any to !<direct_cidr>
pass out route-to (lo0 ::1) proto tcp from any to !<direct_cidr>

dummynet-anchor "com.apple/*"

anchor "com.apple/*"
load anchor "com.apple" from "/etc/pf.anchors/com.apple"
```

/path/to/direct_cidr.txt
```
127.0.0.0/8
::1/128
ipv4_of_your_server/32
ipv6_of_your_server/128
```
run
```
sysctl -w net.inet.ip.forwarding=1
sysctl -w net.inet6.ip6.forwarding=1
pfctl -ef /etc/pf.conf
```