### PR TITLE
proxyproto listener handle conn without header

### DIFF
--- a/common/proxyproto/listener.go
+++ b/common/proxyproto/listener.go
@@ -13,6 +13,7 @@ import (
 
 type Listener struct {
 	net.Listener
+	AcceptNoHeader bool
 }
 
 func (l *Listener) Accept() (net.Conn, error) {
@@ -22,7 +23,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 	}
 	bufReader := std_bufio.NewReader(conn)
 	header, err := proxyproto.Read(bufReader)
-	if err != nil && err != proxyproto.ErrNoProxyProtocol {
+	if err != nil && !(l.AcceptNoHeader && err == proxyproto.ErrNoProxyProtocol) {
 		return nil, err
 	}
 	if bufReader.Buffered() > 0 {

--- a/common/proxyproto/listener.go
+++ b/common/proxyproto/listener.go
@@ -22,7 +22,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 	}
 	bufReader := std_bufio.NewReader(conn)
 	header, err := proxyproto.Read(bufReader)
-	if err != nil {
+	if err != nil && err != proxyproto.ErrNoProxyProtocol {
 		return nil, err
 	}
 	if bufReader.Buffered() > 0 {
@@ -33,8 +33,11 @@ func (l *Listener) Accept() (net.Conn, error) {
 		}
 		conn = bufio.NewCachedConn(conn, cache)
 	}
-	return &bufio.AddrConn{Conn: conn, Metadata: M.Metadata{
-		Source:      M.SocksaddrFromNet(header.SourceAddr),
-		Destination: M.SocksaddrFromNet(header.DestinationAddr),
-	}}, nil
+	if header != nil {
+		return &bufio.AddrConn{Conn: conn, Metadata: M.Metadata{
+			Source:      M.SocksaddrFromNet(header.SourceAddr),
+			Destination: M.SocksaddrFromNet(header.DestinationAddr),
+		}}, nil
+	}
+	return conn, nil
 }

--- a/inbound/default_tcp.go
+++ b/inbound/default_tcp.go
@@ -29,7 +29,7 @@ func (a *myInboundAdapter) ListenTCP() (net.Listener, error) {
 	}
 	if a.listenOptions.ProxyProtocol {
 		a.logger.Debug("proxy protocol enabled")
-		tcpListener = &proxyproto.Listener{Listener: tcpListener}
+		tcpListener = &proxyproto.Listener{Listener: tcpListener, AcceptNoHeader: a.listenOptions.ProxyProtocolAcceptNoHeader}
 	}
 	a.tcpListener = tcpListener
 	return tcpListener, err

--- a/option/inbound.go
+++ b/option/inbound.go
@@ -111,12 +111,13 @@ type InboundOptions struct {
 }
 
 type ListenOptions struct {
-	Listen        ListenAddress `json:"listen"`
-	ListenPort    uint16        `json:"listen_port,omitempty"`
-	TCPFastOpen   bool          `json:"tcp_fast_open,omitempty"`
-	UDPFragment   bool          `json:"udp_fragment,omitempty"`
-	UDPTimeout    int64         `json:"udp_timeout,omitempty"`
-	ProxyProtocol bool          `json:"proxy_protocol,omitempty"`
-	Detour        string        `json:"detour,omitempty"`
+	Listen                      ListenAddress `json:"listen"`
+	ListenPort                  uint16        `json:"listen_port,omitempty"`
+	TCPFastOpen                 bool          `json:"tcp_fast_open,omitempty"`
+	UDPFragment                 bool          `json:"udp_fragment,omitempty"`
+	UDPTimeout                  int64         `json:"udp_timeout,omitempty"`
+	ProxyProtocol               bool          `json:"proxy_protocol,omitempty"`
+	ProxyProtocolAcceptNoHeader bool          `json:"proxy_protocol_accept_no_header,omitempty"`
+	Detour                      string        `json:"detour,omitempty"`
 	InboundOptions
 }


### PR DESCRIPTION
When proxyproto is enabled in listener, it should also handle normal connection without a proxyproto header.