### PR TITLE
fix: skip sending a connect packet when ip is unspecified

### DIFF
--- a/outbound/default.go
+++ b/outbound/default.go
@@ -79,7 +79,7 @@ func NewEarlyConnection(ctx context.Context, this N.Dialer, conn net.Conn, metad
 func NewPacketConnection(ctx context.Context, this N.Dialer, conn N.PacketConn, metadata adapter.InboundContext) error {
 	switch metadata.Protocol {
 	case C.ProtocolQUIC, C.ProtocolDNS:
-		if !metadata.Destination.Addr.IsUnspecified() && metadata.Destination.Port != 0 {
+		if !metadata.Destination.Addr.IsUnspecified() {
 			return connectPacketConnection(ctx, this, conn, metadata)
 		}
 	}

--- a/outbound/default.go
+++ b/outbound/default.go
@@ -79,7 +79,9 @@ func NewEarlyConnection(ctx context.Context, this N.Dialer, conn net.Conn, metad
 func NewPacketConnection(ctx context.Context, this N.Dialer, conn N.PacketConn, metadata adapter.InboundContext) error {
 	switch metadata.Protocol {
 	case C.ProtocolQUIC, C.ProtocolDNS:
-		return connectPacketConnection(ctx, this, conn, metadata)
+		if !metadata.Destination.Addr.IsUnspecified() && metadata.Destination.Port != 0 {
+			return connectPacketConnection(ctx, this, conn, metadata)
+		}
 	}
 	ctx = adapter.WithContext(ctx, &metadata)
 	var outConn net.PacketConn


### PR DESCRIPTION
#158 