### PR TITLE
Multiple config files & formats support

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -42,12 +42,12 @@ $ sing-box format -w
 
 > You can skip this section if you are using only one configuration file.
 
-sing-box supports multiple files and multiple formats. The latter overwrites and merges into the former, in the order in which the configuration files are loaded.
+sing-box supports multiple configuration files. The latter overwrites and merges into the former, in the order in which the configuration files are loaded.
 
 
 ```bash
 # Load by the order of parameters
-sing-box run -c inbound.json -c outbound.yaml -c  -c http://url.to/config.toml
+sing-box run -c inbound.json -c outbound.json
 # Load by the order of file names
 sing-box run -r -c config_dir
 ```

--- a/docs/configuration/index.zh.md
+++ b/docs/configuration/index.zh.md
@@ -1,6 +1,6 @@
 # 引言
 
-sing-box 支持 JSON、JSONC、YAML、TOML 作为配置文件格式。
+sing-box 使用 JSON 作为配置文件格式。
 
 ### 结构
 
@@ -42,11 +42,11 @@ $ sing-box format -w
 
 > 如果只使用单个配置文件，您完全可以忽略这一节。
 
-sing-box 支持多文件、多格式混合使用。按照配置文件的加载顺序，后者会覆盖并合并到前者。
+sing-box 支持多文件配置。按照配置文件的加载顺序，后者会覆盖并合并到前者。
 
 ```bash
 # 根据参数顺序加载
-sing-box run -c inbound.json -c outbound.yaml -c http://url.to/config.toml
+sing-box run -c inbound.json -c outbound.json
 # 根据文件名顺序加载
 sing-box run -r -c config_dir
 ```


### PR DESCRIPTION
The PR ports `Multiple config files formats support` to sing-box which is committed here: https://github.com/v2fly/v2ray-core/pull/451

```
> ./sing-box  
Usage:
  sing-box [command]

Available Commands:
  check       Check configuration
  completion  Generate the autocompletion script for the specified shell
  format      Format configuration
  help        Help about any command
  run         Run service
  version     Print current version of sing-box

Flags:
  -c, --config stringArray     set configuration files / directories (default [config.json])
      --config-format string   configuration files format: auto, json, jsonc, yaml, toml (default "auto")
  -r, --config-recursive       load configuration directories recursively
  -D, --directory string       set working directory
      --disable-color          disable color output
  -h, --help                   help for sing-box
```