### PR TITLE
Update uTLS usage

### DIFF
--- a/common/tls/utls_client.go
+++ b/common/tls/utls_client.go
@@ -3,7 +3,6 @@
 package tls
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -40,10 +39,6 @@ func (e *utlsClientConfig) Client(conn net.Conn) Conn {
 
 type utlsConnWrapper struct {
 	*utls.UConn
-}
-
-func (c *utlsConnWrapper) HandshakeContext(ctx context.Context) error {
-	return c.UConn.Handshake()
 }
 
 func (c *utlsConnWrapper) ConnectionState() tls.ConnectionState {
@@ -140,6 +135,14 @@ func newUTLSClient(router adapter.Router, serverAddress string, options option.O
 		id = utls.HelloChrome_Auto
 	case "firefox":
 		id = utls.HelloFirefox_Auto
+	case "edge":
+		id = utls.HelloEdge_Auto
+	case "safari":
+		id = utls.HelloSafari_Auto
+	case "360":
+		id = utls.Hello360_Auto
+	case "qq":
+		id = utls.HelloQQ_Auto
 	case "ios":
 		id = utls.HelloIOS_Auto
 	case "android":

--- a/docs/configuration/shared/tls.md
+++ b/docs/configuration/shared/tls.md
@@ -192,10 +192,15 @@ Available fingerprint values:
 
 * chrome
 * firefox
+* edge
+* safari
+* 360
+* qq
 * ios
 * android
 * random
 
+Chrome fingerprint will be used if empty.
 
 ### ACME Fields
 

--- a/docs/configuration/shared/tls.zh.md
+++ b/docs/configuration/shared/tls.zh.md
@@ -192,9 +192,15 @@ uTLS 是 "crypto/tls" 的一个分支，它提供了 ClientHello 指纹识别阻
 
 * chrome
 * firefox
+* edge
+* safari
+* 360
+* qq
 * ios
 * android
 * random
+
+默认使用 chrome 指纹。
 
 ### ACME 字段
 


### PR DESCRIPTION
Dear nekohasekai,  
  
Upstream uTLS has synchronized to Go crypto/tls, so I minimized the wrapper by removing `HandshakeContext` method, which is already provided.  
Also, there are four new fingerprints have been added to this update, including browsers that come from China. I'll also update the documentation soon.  
  
Best regards,
Hellojack