### PR TITLE
Update install.sh

### DIFF
--- a/release/local/install.sh
+++ b/release/local/install.sh
@@ -17,4 +17,5 @@ sudo cp $(go env GOPATH)/bin/sing-box /usr/local/bin/
 sudo mkdir -p /usr/local/etc/sing-box
 sudo cp $PROJECT/release/config/config.json /usr/local/etc/sing-box/config.json
 sudo cp $DIR/sing-box.service /etc/systemd/system
+sudo mkdir -p /var/lib/sing-box
 sudo systemctl daemon-reload


### PR DESCRIPTION
Fixing sing-box does not work after the compilation and installation on Linux server, the modification is because of the systemd file change.

Signed-off-by: 嫦悅 <snc@turbohk.cc>