### PR TITLE
V2Ray API: User stats

### DIFF
--- a/adapter/experimental.go
+++ b/adapter/experimental.go
@@ -45,6 +45,6 @@ type V2RayServer interface {
 }
 
 type V2RayStatsService interface {
-	RoutedConnection(inbound string, outbound string, conn net.Conn) net.Conn
-	RoutedPacketConnection(inbound string, outbound string, conn N.PacketConn) N.PacketConn
+	RoutedConnection(inbound string, outbound string, user string, conn net.Conn) net.Conn
+	RoutedPacketConnection(inbound string, outbound string, user string, conn N.PacketConn) N.PacketConn
 }

--- a/experimental/v2rayapi/stats.go
+++ b/experimental/v2rayapi/stats.go
@@ -55,7 +55,7 @@ func NewStatsService(options option.V2RayStatsServiceOptions) *StatsService {
 	}
 }
 
-func (s *StatsService) RoutedConnection(inbound string, outbound string, conn net.Conn) net.Conn {
+func (s *StatsService) RoutedConnection(inbound string, outbound string, user string, conn net.Conn) net.Conn {
 	var readCounter []*atomic.Int64
 	var writeCounter []*atomic.Int64
 	countInbound := inbound != "" && s.inbounds[inbound]
@@ -67,6 +67,10 @@ func (s *StatsService) RoutedConnection(inbound string, outbound string, conn ne
 	if countInbound {
 		readCounter = append(readCounter, s.loadOrCreateCounter("inbound>>>"+inbound+">>>traffic>>>uplink"))
 		writeCounter = append(writeCounter, s.loadOrCreateCounter("inbound>>>"+inbound+">>>traffic>>>downlink"))
+		if user != "" {
+			readCounter = append(readCounter, s.loadOrCreateCounter("user>>>"+user+">>>traffic>>>uplink"))
+			writeCounter = append(writeCounter, s.loadOrCreateCounter("user>>>"+user+">>>traffic>>>downlink"))
+		}
 	}
 	if countOutbound {
 		readCounter = append(readCounter, s.loadOrCreateCounter("outbound>>>"+outbound+">>>traffic>>>uplink"))
@@ -76,7 +80,7 @@ func (s *StatsService) RoutedConnection(inbound string, outbound string, conn ne
 	return trackerconn.New(conn, readCounter, writeCounter)
 }
 
-func (s *StatsService) RoutedPacketConnection(inbound string, outbound string, conn N.PacketConn) N.PacketConn {
+func (s *StatsService) RoutedPacketConnection(inbound string, outbound string, user string, conn N.PacketConn) N.PacketConn {
 	var readCounter []*atomic.Int64
 	var writeCounter []*atomic.Int64
 	countInbound := inbound != "" && s.inbounds[inbound]
@@ -88,6 +92,10 @@ func (s *StatsService) RoutedPacketConnection(inbound string, outbound string, c
 	if countInbound {
 		readCounter = append(readCounter, s.loadOrCreateCounter("inbound>>>"+inbound+">>>traffic>>>uplink"))
 		writeCounter = append(writeCounter, s.loadOrCreateCounter("inbound>>>"+inbound+">>>traffic>>>downlink"))
+		if user != "" {
+			readCounter = append(readCounter, s.loadOrCreateCounter("user>>>"+user+">>>traffic>>>uplink"))
+			writeCounter = append(writeCounter, s.loadOrCreateCounter("user>>>"+user+">>>traffic>>>downlink"))
+		}
 	}
 	if countOutbound {
 		readCounter = append(readCounter, s.loadOrCreateCounter("outbound>>>"+outbound+">>>traffic>>>uplink"))

--- a/route/router.go
+++ b/route/router.go
@@ -24,9 +24,9 @@ import (
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-dns"
-	"github.com/sagernet/sing-tun"
-	"github.com/sagernet/sing-vmess"
+	dns "github.com/sagernet/sing-dns"
+	tun "github.com/sagernet/sing-tun"
+	vmess "github.com/sagernet/sing-vmess"
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
 	"github.com/sagernet/sing/common/bufio"
@@ -583,7 +583,7 @@ func (r *Router) RouteConnection(ctx context.Context, conn net.Conn, metadata ad
 	}
 	if r.v2rayServer != nil {
 		if statsService := r.v2rayServer.StatsService(); statsService != nil {
-			conn = statsService.RoutedConnection(metadata.Inbound, detour.Tag(), conn)
+			conn = statsService.RoutedConnection(metadata.Inbound, detour.Tag(), metadata.User, conn)
 		}
 	}
 	return detour.NewConnection(ctx, conn, metadata)
@@ -661,7 +661,7 @@ func (r *Router) RoutePacketConnection(ctx context.Context, conn N.PacketConn, m
 	}
 	if r.v2rayServer != nil {
 		if statsService := r.v2rayServer.StatsService(); statsService != nil {
-			conn = statsService.RoutedPacketConnection(metadata.Inbound, detour.Tag(), conn)
+			conn = statsService.RoutedPacketConnection(metadata.Inbound, detour.Tag(), metadata.User, conn)
 		}
 	}
 	return detour.NewPacketConnection(ctx, conn, metadata)


### PR DESCRIPTION
Issue: https://github.com/SagerNet/sing-box/issues/185

Added per-user counter.

```bash
$ ./v2ray api stats --server=sing-box:54321
    Value       Name
1   98.59KB     inbound>>>mixed-in>>>traffic>>>downlink
2   4.63MB      inbound>>>mixed-in>>>traffic>>>uplink
3   491.08KB    inbound>>>trojan-in>>>traffic>>>downlink
4   411.95KB    inbound>>>trojan-in>>>traffic>>>uplink
5   417.42KB    outbound>>>trojan-out>>>traffic>>>downlink
6   376.67KB    outbound>>>trojan-out>>>traffic>>>uplink
7   491.08KB    user>>>user-1>>>traffic>>>downlink
8   411.95KB    user>>>user-1>>>traffic>>>uplink
9   98.59KB     user>>>user-2>>>traffic>>>downlink
10  4.63MB      user>>>user-2>>>traffic>>>uplink

Total: 11.99MB
```