### PR TITLE
fix: systemd service caps for process sniffing

### DIFF
--- a/release/config/sing-box.service
+++ b/release/config/sing-box.service
@@ -5,8 +5,8 @@ After=network.target nss-lookup.target
 
 [Service]
 WorkingDirectory=/var/lib/sing-box
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=/usr/bin/sing-box run -c /etc/sing-box/config.json
 Restart=on-failure
 RestartSec=10s

--- a/release/config/sing-box@.service
+++ b/release/config/sing-box@.service
@@ -5,8 +5,8 @@ After=network.target nss-lookup.target
 
 [Service]
 WorkingDirectory=/var/lib/sing-box-%i
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=/usr/bin/sing-box run -c /etc/sing-box/%i.json
 Restart=on-failure
 RestartSec=10s

--- a/release/local/sing-box.service
+++ b/release/local/sing-box.service
@@ -5,8 +5,8 @@ After=network.target nss-lookup.target
 
 [Service]
 WorkingDirectory=/var/lib/sing-box
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=/usr/local/bin/sing-box run -c /usr/local/etc/sing-box/config.json
 Restart=on-failure
 RestartSec=10s


### PR DESCRIPTION
If sing-box running as a normal user, we need to explicitly specify this permission for process sniffing to work properly.