### PR TITLE
Handle too large hostLen.

### DIFF
--- a/transport/hysteria/protocol.go
+++ b/transport/hysteria/protocol.go
@@ -293,8 +293,8 @@ func ParseUDPMessage(packet []byte) (message UDPMessage, err error) {
 	if err != nil {
 		return
 	}
-	if int(6+hostLen) > len(packet) {
-		err = E.New("Invalid hostLen")
+	if 6+int(hostLen) > len(packet) {
+		err = E.New("invalid host length")
 		return
 	}
 	message.Host = string(packet[6 : 6+hostLen])

--- a/transport/hysteria/protocol.go
+++ b/transport/hysteria/protocol.go
@@ -293,6 +293,10 @@ func ParseUDPMessage(packet []byte) (message UDPMessage, err error) {
 	if err != nil {
 		return
 	}
+	if int(6+hostLen) > len(packet) {
+		err = E.New("Invalid hostLen")
+		return
+	}
 	message.Host = string(packet[6 : 6+hostLen])
 	err = binary.Read(reader, binary.BigEndian, &message.Port)
 	if err != nil {


### PR DESCRIPTION
This pops up in my log

```
 panic: runtime error: slice bounds out of range [:8821] with capacity 1160
 goroutine 4747 [running]:
 github.com/sagernet/sing-box/transport/hysteria.ParseUDPMessage({0xc000265900, 0x488, 0x488})
         github.com/sagernet/sing-box/transport/hysteria/protocol.go:296 +0x68b
 github.com/sagernet/sing-box/inbound.(*Hysteria).udpRecvLoop(0xc00012f680, {0xf20fc8, 0xc00010f800})
         github.com/sagernet/sing-box/inbound/hysteria.go:246 +0x92
 created by github.com/sagernet/sing-box/inbound.(*Hysteria).accept
         github.com/sagernet/sing-box/inbound/hysteria.go:223 +0x7ea
```

Apparently the preceding `Seek` operation does not validate the length, so we need to do the validation manually.