### PR TITLE
Add support for TLS client certificate auth

### DIFF
--- a/common/tls/common.go
+++ b/common/tls/common.go
@@ -1,5 +1,12 @@
 package tls
 
+import (
+	"crypto/x509"
+	"os"
+
+	E "github.com/sagernet/sing/common/exceptions"
+)
+
 const (
 	VersionTLS10 = 0x0301
 	VersionTLS11 = 0x0302
@@ -10,3 +17,31 @@ const (
 	// supported by this package. See golang.org/issue/32716.
 	VersionSSL30 = 0x0300
 )
+
+func loadCertAsBytes(certificate string, certificatePath string) ([]byte, error) {
+	if certificate != "" {
+		return []byte(certificate), nil
+	} else if certificatePath != "" {
+		content, err := os.ReadFile(certificatePath)
+		if err != nil {
+			return nil, E.Cause(err, "read certificate")
+		}
+		return content, nil
+	}
+	return nil, nil
+}
+
+func loadCertAsPool(certificate string, certificatePath string) (*x509.CertPool, error) {
+	certBytes, err := loadCertAsBytes(certificate, certificatePath)
+	if err != nil {
+		return nil, err
+	}
+	if certBytes == nil {
+		return nil, nil
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(certBytes) {
+		return nil, E.New("failed to parse certificate:\n\n", certBytes)
+	}
+	return certPool, nil
+}

--- a/common/tls/std_client.go
+++ b/common/tls/std_client.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"net"
 	"net/netip"
-	"os"
 
 	"github.com/sagernet/sing-box/option"
 	E "github.com/sagernet/sing/common/exceptions"
@@ -107,22 +106,31 @@ func NewSTDClient(serverAddress string, options option.OutboundTLSOptions) (Conf
 			return nil, E.New("unknown cipher_suite: ", cipherSuite)
 		}
 	}
-	var certificate []byte
-	if options.Certificate != "" {
-		certificate = []byte(options.Certificate)
-	} else if options.CertificatePath != "" {
-		content, err := os.ReadFile(options.CertificatePath)
-		if err != nil {
-			return nil, E.Cause(err, "read certificate")
-		}
-		certificate = content
+	certPool, err := loadCertAsPool(options.Certificate, options.CertificatePath)
+	if err != nil {
+		return nil, E.Cause(err, "load certificate")
 	}
-	if len(certificate) > 0 {
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(certificate) {
-			return nil, E.New("failed to parse certificate:\n\n", certificate)
-		}
+	if certPool != nil {
 		tlsConfig.RootCAs = certPool
+	}
+	clientCert, err := loadCertAsBytes(options.ClientCertificate, options.ClientCertificatePath)
+	if err != nil {
+		return nil, E.Cause(err, "load client certificate")
+	}
+	clientKey, err := loadCertAsBytes(options.ClientKey, options.ClientKeyPath)
+	if err != nil {
+		return nil, E.Cause(err, "load client certificate key")
+	}
+	if clientCert != nil && clientKey == nil {
+		return nil, E.New("Client certificate specified without a client key")
+	} else if clientCert == nil && clientKey != nil {
+		return nil, E.New("Client key specified without a client certificate")
+	} else if clientCert != nil && clientKey != nil {
+		clientKeyPair, err := tls.X509KeyPair(clientCert, clientKey)
+		if err != nil {
+			return nil, E.Cause(err, "parse client certificate/key")
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientKeyPair}
 	}
 	return &STDClientConfig{&tlsConfig}, nil
 }

--- a/common/tls/std_server.go
+++ b/common/tls/std_server.go
@@ -246,6 +246,14 @@ func NewSTDServer(ctx context.Context, logger log.Logger, options option.Inbound
 			tlsConfig.Certificates = []tls.Certificate{keyPair}
 		}
 	}
+	clientCA, err := loadCertAsPool(options.ClientCA, options.ClientCAPath)
+	if err != nil {
+		return nil, E.Cause(err, "load client CA")
+	}
+	if clientCA != nil {
+		tlsConfig.ClientCAs = clientCA
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
 	return &STDServerConfig{
 		config:          tlsConfig,
 		logger:          logger,

--- a/option/tls.go
+++ b/option/tls.go
@@ -12,22 +12,28 @@ type InboundTLSOptions struct {
 	CertificatePath string              `json:"certificate_path,omitempty"`
 	Key             string              `json:"key,omitempty"`
 	KeyPath         string              `json:"key_path,omitempty"`
+	ClientCA        string              `json:"client_ca,omitempty"`
+	ClientCAPath    string              `json:"client_ca_path,omitempty"`
 	ACME            *InboundACMEOptions `json:"acme,omitempty"`
 }
 
 type OutboundTLSOptions struct {
-	Enabled         bool                 `json:"enabled,omitempty"`
-	DisableSNI      bool                 `json:"disable_sni,omitempty"`
-	ServerName      string               `json:"server_name,omitempty"`
-	Insecure        bool                 `json:"insecure,omitempty"`
-	ALPN            Listable[string]     `json:"alpn,omitempty"`
-	MinVersion      string               `json:"min_version,omitempty"`
-	MaxVersion      string               `json:"max_version,omitempty"`
-	CipherSuites    Listable[string]     `json:"cipher_suites,omitempty"`
-	Certificate     string               `json:"certificate,omitempty"`
-	CertificatePath string               `json:"certificate_path,omitempty"`
-	ECH             *OutboundECHOptions  `json:"ech,omitempty"`
-	UTLS            *OutboundUTLSOptions `json:"utls,omitempty"`
+	Enabled               bool                 `json:"enabled,omitempty"`
+	DisableSNI            bool                 `json:"disable_sni,omitempty"`
+	ServerName            string               `json:"server_name,omitempty"`
+	Insecure              bool                 `json:"insecure,omitempty"`
+	ALPN                  Listable[string]     `json:"alpn,omitempty"`
+	MinVersion            string               `json:"min_version,omitempty"`
+	MaxVersion            string               `json:"max_version,omitempty"`
+	CipherSuites          Listable[string]     `json:"cipher_suites,omitempty"`
+	Certificate           string               `json:"certificate,omitempty"`
+	CertificatePath       string               `json:"certificate_path,omitempty"`
+	ClientCertificate     string               `json:"client_certificate,omitempty"`
+	ClientCertificatePath string               `json:"client_certificate_path,omitempty"`
+	ClientKey             string               `json:"client_key,omitempty"`
+	ClientKeyPath         string               `json:"client_key_path,omitempty"`
+	ECH                   *OutboundECHOptions  `json:"ech,omitempty"`
+	UTLS                  *OutboundUTLSOptions `json:"utls,omitempty"`
 }
 
 type OutboundECHOptions struct {


### PR DESCRIPTION
The primary purpose is to defeat active probing, since any probes will fail at TLS handshake and not be able to further test the underlying application protocol.

TLS client authentication is not used often on the Internet, but most of the users are big companies, so I don't think its presence will trigger more stringent blocking.