### PR TITLE
Fix incorrect NTP server address.

### DIFF
--- a/docs/configuration/ntp/index.md
+++ b/docs/configuration/ntp/index.md
@@ -11,7 +11,7 @@ synchronization is not possible.
 {
   "ntp": {
     "enabled": false,
-    "server": "ntp.apple.com",
+    "server": "time.apple.com",
     "server_port": 123,
     "interval": "30m",
     

--- a/docs/configuration/ntp/index.zh.md
+++ b/docs/configuration/ntp/index.zh.md
@@ -10,7 +10,7 @@
 {
   "ntp": {
     "enabled": false,
-    "server": "ntp.apple.com",
+    "server": "time.apple.com",
     "server_port": 123,
     "interval": "30m",
     


### PR DESCRIPTION
"ntp.apple.com" doesn't have valid DNS records. Use "time.apple.com" instead. 