### PR TITLE
Delete WorkingDirectory in sing-box.service

### DIFF
--- a/release/config/sing-box.service
+++ b/release/config/sing-box.service
@@ -4,7 +4,6 @@ Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target
 
 [Service]
-WorkingDirectory=/var/lib/sing-box
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=/usr/bin/sing-box run -c /etc/sing-box/config.json

--- a/release/config/sing-box@.service
+++ b/release/config/sing-box@.service
@@ -4,7 +4,6 @@ Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target
 
 [Service]
-WorkingDirectory=/var/lib/sing-box-%i
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=/usr/bin/sing-box run -c /etc/sing-box/%i.json

--- a/release/local/sing-box.service
+++ b/release/local/sing-box.service
@@ -4,7 +4,6 @@ Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target
 
 [Service]
-WorkingDirectory=/var/lib/sing-box
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 ExecStart=/usr/local/bin/sing-box run -c /usr/local/etc/sing-box/config.json


### PR DESCRIPTION
Delete WorkingDirectory in sing-box.service, because neither the binary and configuration file are located in this working directory. It may confuse new users.