### PR TITLE
Add fallback support

### DIFF
--- a/option/clash.go
+++ b/option/clash.go
@@ -15,8 +15,10 @@ type SelectorOutboundOptions struct {
 }
 
 type URLTestOutboundOptions struct {
-	Outbounds []string `json:"outbounds"`
-	URL       string   `json:"url,omitempty"`
-	Interval  Duration `json:"interval,omitempty"`
-	Tolerance uint16   `json:"tolerance,omitempty"`
+	Outbounds     []string `json:"outbounds"`
+	URL           string   `json:"url,omitempty"`
+	Interval      Duration `json:"interval,omitempty"`
+	Tolerance     uint16   `json:"tolerance,omitempty"`
+	Fallback      bool     `json:"fallback,omitempty"`
+	MaxAllowDelay uint16   `json:"max_allow_delay,omitempty"`
 }


### PR DESCRIPTION
#127 

```
    {
      "type": "urltest",
      "tag": "PROXY",
      "outbounds": [
        "hk1",
        "hk2",
        "hk3",
        "jp1",
        "jp2"
      ],
      "default": "IPLC-SZ-HK",
      "fallback": true, // 启用自动回落
      "max_allow_delay": 600 // 当遇到网络不稳定时，启用fallback后可能导致因延迟过高选中劣质节点，如果延迟超过此选项设置，则在选择中自动丢弃超过延迟高于此选项值的节点，单位：ms
      // 例如：hk1：700ms   hk2：100ms，此时 hk1 因延迟超过阈值 600ms，丢弃，会选择顺位的 hk2（若 hk2 延迟不超过阈值），以此类推；当所有节点延迟都超过阈值，则按照顺位自动选择。
    }
```