### PR TITLE
Fix '?' at end of WebSocket path get escaped

### DIFF
--- a/transport/v2raywebsocket/client.go
+++ b/transport/v2raywebsocket/client.go
@@ -61,6 +61,10 @@ func NewClient(ctx context.Context, dialer N.Dialer, serverAddr M.Socksaddr, opt
 	if !strings.HasPrefix(uri.Path, "/") {
 		uri.Path = "/" + uri.Path
 	}
+	if strings.HasSuffix(uri.Path, "?") {
+		uri.ForceQuery = true
+		uri.Path = strings.TrimSuffix(uri.Path, "?")
+	}
 	headers := make(http.Header)
 	for key, value := range options.Headers {
 		headers[key] = value


### PR DESCRIPTION
This fix align sing-box's behaviour with V2Ray when it comes to processing ? at the end of WebSocket's path.