### PR TITLE
Fix: Linux service start command

### DIFF
--- a/release/local/sing-box.service
+++ b/release/local/sing-box.service
@@ -6,7 +6,7 @@ After=network.target nss-lookup.target
 [Service]
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
-ExecStart=/usr/local/bin/sing-box -D /var/lib/sing-box -C /usr/local/etc/sing-box run
+ExecStart=/usr/local/bin/sing-box -D /var/lib/sing-box -c /usr/local/etc/sing-box/config.json run
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=10s


### PR DESCRIPTION
The config.json parameter shall be `-c` instead of `-C`