### PR TITLE
Fix clash api proxies sort

### DIFF
--- a/experimental/clashapi/proxies.go
+++ b/experimental/clashapi/proxies.go
@@ -134,7 +134,7 @@ func getProxies(server *Server, router adapter.Router) func(w http.ResponseWrite
 			defaultTag = allProxies[0]
 		}
 
-		sort.Slice(allProxies, func(i, j int) bool {
+		sort.SliceStable(allProxies, func(i, j int) bool {
 			return allProxies[i] == defaultTag
 		})
 

--- a/outbound/urltest.go
+++ b/outbound/urltest.go
@@ -233,7 +233,7 @@ func (g *URLTestGroup) Fallback(used adapter.Outbound) []adapter.Outbound {
 			outbounds = append(outbounds, detour)
 		}
 	}
-	sort.Slice(outbounds, func(i, j int) bool {
+	sort.SliceStable(outbounds, func(i, j int) bool {
 		oi := outbounds[i]
 		oj := outbounds[j]
 		hi := g.history.LoadURLTestHistory(RealTag(oi))


### PR DESCRIPTION
Make the order of proxies in clash api to be same as them in config file.

https://github.com/haishanh/yacd/blob/e533e8e959d1664273d44723524fda883eb8a264/src/store/proxies.tsx#L379-L382