### PR TITLE
Fixed outbound strategy

### DIFF
--- a/common/dialer/dialer.go
+++ b/common/dialer/dialer.go
@@ -17,7 +17,7 @@ func New(router adapter.Router, options option.DialerOptions) N.Dialer {
 		dialer = NewDetour(router, options.Detour)
 	}
 	domainStrategy := dns.DomainStrategy(options.DomainStrategy)
-	if domainStrategy != dns.DomainStrategyAsIS || options.Detour == "" {
+	if domainStrategy != dns.DomainStrategyAsIS && options.Detour == "" {
 		dialer = NewResolveDialer(router, dialer, domainStrategy, time.Duration(options.FallbackDelay))
 	}
 	return dialer


### PR DESCRIPTION
Direct outbound and other outbound current strategy swaps. If domain_strategy is set on inbound, all outbound resolve the domain in request. If domain_strategy is not set on inbound and domain_strategy is set on direct outbound, the requested domain is not resolved before connection. 
Only one logical operator has been modified.