### PR TITLE
add ip_on_demand for route

### DIFF
--- a/adapter/inbound.go
+++ b/adapter/inbound.go
@@ -32,6 +32,7 @@ type InboundContext struct {
 	Source      M.Socksaddr
 	Destination M.Socksaddr
 	Domain      string
+	IPs         []netip.Addr
 	Protocol    string
 	User        string
 	Outbound    string

--- a/option/route.go
+++ b/option/route.go
@@ -10,6 +10,7 @@ type RouteOptions struct {
 	OverrideAndroidVPN  bool            `json:"override_android_vpn,omitempty"`
 	DefaultInterface    string          `json:"default_interface,omitempty"`
 	DefaultMark         int             `json:"default_mark,omitempty"`
+	IPOnDemand          bool            `json:"ip_on_demand,omitempty"`
 }
 
 type GeoIPOptions struct {

--- a/route/rule_item_cidr.go
+++ b/route/rule_item_cidr.go
@@ -69,6 +69,11 @@ func (r *IPCIDRItem) Match(metadata *adapter.InboundContext) bool {
 					return true
 				}
 			}
+			for _, address := range metadata.IPs {
+				if r.ipSet.Contains(address) {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/route/rule_item_geoip.go
+++ b/route/rule_item_geoip.go
@@ -57,6 +57,11 @@ func (r *GeoIPItem) Match(metadata *adapter.InboundContext) bool {
 			return true
 		}
 	}
+	for _, ip := range metadata.IPs {
+		if r.match(metadata, ip) {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
This is for socks5, http, etc. inbounds that can receive domain endpoint, and this makes no sense for tun.

If inbound domain_strategy is set, outbound server will receive ip endpoints. However, one may want that inbound connections with domain endpoint can match both domain and ip rules, but still send domain endpoint to outbound server.