### PR TITLE
tls: add RejectUnknownSNI

### DIFF
--- a/option/tls.go
+++ b/option/tls.go
@@ -1,20 +1,20 @@
 package option
 
 type InboundTLSOptions struct {
-	Enabled         bool                   `json:"enabled,omitempty"`
-	ServerName      string                 `json:"server_name,omitempty"`
-	Insecure        bool                   `json:"insecure,omitempty"`
-	RejectHandshake bool                   `json:"reject_handshake,omitempty"`
-	ALPN            Listable[string]       `json:"alpn,omitempty"`
-	MinVersion      string                 `json:"min_version,omitempty"`
-	MaxVersion      string                 `json:"max_version,omitempty"`
-	CipherSuites    Listable[string]       `json:"cipher_suites,omitempty"`
-	Certificate     string                 `json:"certificate,omitempty"`
-	CertificatePath string                 `json:"certificate_path,omitempty"`
-	Key             string                 `json:"key,omitempty"`
-	KeyPath         string                 `json:"key_path,omitempty"`
-	ACME            *InboundACMEOptions    `json:"acme,omitempty"`
-	Reality         *InboundRealityOptions `json:"reality,omitempty"`
+	Enabled          bool                   `json:"enabled,omitempty"`
+	ServerName       string                 `json:"server_name,omitempty"`
+	Insecure         bool                   `json:"insecure,omitempty"`
+	RejectUnknownSNI bool                   `json:"reject_unknown_sni,omitempty"`
+	ALPN             Listable[string]       `json:"alpn,omitempty"`
+	MinVersion       string                 `json:"min_version,omitempty"`
+	MaxVersion       string                 `json:"max_version,omitempty"`
+	CipherSuites     Listable[string]       `json:"cipher_suites,omitempty"`
+	Certificate      string                 `json:"certificate,omitempty"`
+	CertificatePath  string                 `json:"certificate_path,omitempty"`
+	Key              string                 `json:"key,omitempty"`
+	KeyPath          string                 `json:"key_path,omitempty"`
+	ACME             *InboundACMEOptions    `json:"acme,omitempty"`
+	Reality          *InboundRealityOptions `json:"reality,omitempty"`
 }
 
 type OutboundTLSOptions struct {

--- a/option/tls.go
+++ b/option/tls.go
@@ -4,6 +4,7 @@ type InboundTLSOptions struct {
 	Enabled         bool                   `json:"enabled,omitempty"`
 	ServerName      string                 `json:"server_name,omitempty"`
 	Insecure        bool                   `json:"insecure,omitempty"`
+	RejectHandshake bool                   `json:"reject_handshake,omitempty"`
 	ALPN            Listable[string]       `json:"alpn,omitempty"`
 	MinVersion      string                 `json:"min_version,omitempty"`
 	MaxVersion      string                 `json:"max_version,omitempty"`


### PR DESCRIPTION
```jsonc
{
    "inbounds": [
        {
            // ... Other
            "tls": {
                "enabled": true,
                // "server_name": "example.com",  // Optional
                "certificate_path": "./your.crt",
                "key_path": "./your.key",
                "reject_unknown_sni": true
            }
        }
    ]
}
```
reject_unknown_sni

当客户端发送的 SNI 无法与 `server_name` 或 TLS 证书有效域名匹配时，终止 TLS 握手。
