### PR TITLE
feat: sniff_override_fallback

### DIFF
--- a/docs/configuration/shared/listen.md
+++ b/docs/configuration/shared/listen.md
@@ -8,6 +8,7 @@
   "udp_fragment": false,
   "sniff": false,
   "sniff_override_destination": false,
+  "sniff_override_fallback": false,
   "sniff_timeout": "300ms",
   "domain_strategy": "prefer_ipv6",
   "udp_timeout": 300,
@@ -57,6 +58,12 @@ See [Protocol Sniff](/configuration/route/sniff/) for details.
 Override the connection destination address with the sniffed domain.
 
 If the domain name is invalid (like tor), this will not work.
+
+#### sniff_override_fallback
+
+If the sniffed domain fails to be resolved when `sniff_override_destination` is enabled, use the original destination address as fallback.
+
+Helpful when using customized domain.
 
 #### sniff_timeout
 

--- a/docs/configuration/shared/listen.zh.md
+++ b/docs/configuration/shared/listen.zh.md
@@ -8,6 +8,7 @@
   "udp_fragment": false,
   "sniff": false,
   "sniff_override_destination": false,
+  "sniff_override_fallback": false,
   "sniff_timeout": "300ms",
   "domain_strategy": "prefer_ipv6",
   "udp_timeout": 300,
@@ -58,6 +59,12 @@
 用探测出的域名覆盖连接目标地址。
 
 如果域名无效（如 Tor），将不生效。
+
+#### sniff_override_fallback
+
+当 `sniff_override_destination` 开启且探测出的域名解析失败时，回退使用原连接目标地址。
+
+当使用自定义域名时有帮助。
 
 #### sniff_timeout
 

--- a/option/inbound.go
+++ b/option/inbound.go
@@ -112,6 +112,7 @@ func (h *Inbound) UnmarshalJSON(bytes []byte) error {
 type InboundOptions struct {
 	SniffEnabled             bool           `json:"sniff,omitempty"`
 	SniffOverrideDestination bool           `json:"sniff_override_destination,omitempty"`
+	SniffOverrideFallback    bool           `json:"sniff_override_fallback,omitempty"`
 	SniffTimeout             Duration       `json:"sniff_timeout,omitempty"`
 	DomainStrategy           DomainStrategy `json:"domain_strategy,omitempty"`
 }


### PR DESCRIPTION
If the sniffed domain fails to be resolved when `sniff_override_destination` is enabled, use the original destination address as fallback.

Helpful when using customized domain.
