### PR TITLE
Add customizable build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ COMMIT = $(shell git rev-parse --short HEAD)
 TAGS_GO118 = with_gvisor,with_dhcp,with_wireguard,with_utls,with_reality_server,with_clash_api
 TAGS_GO120 ?= with_quic
 TAGS_TEST ?= with_gvisor,with_quic,with_wireguard,with_grpc,with_ech,with_utls,with_reality_server,with_shadowsocksr
+TAGS ?= $(TAGS_GO118),$(TAGS_GO120)
 
 GOHOSTOS = $(shell go env GOHOSTOS)
 GOHOSTARCH = $(shell go env GOHOSTARCH)
 VERSION=$(shell CGO_ENABLED=0 GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) go run ./cmd/internal/read_tag)
 
 PARAMS = -v -trimpath -ldflags "-X 'github.com/sagernet/sing-box/constant.Version=$(VERSION)' -s -w -buildid="
-MAIN_PARAMS = $(PARAMS) -tags "$(TAGS_GO118),$(TAGS_GO120)"
+MAIN_PARAMS = $(PARAMS) -tags "$(TAGS)"
 MAIN = ./cmd/sing-box
 PREFIX ?= $(shell go env GOPATH)
 


### PR DESCRIPTION
After commit 4925553 [Fix ci build](https://github.com/SagerNet/sing-box/commit/4925553aa3e7c5eadaaddfe9fc06e6e967532cf3) , we cannot use `TAGS="..." make build` to build kernel with customized tags. This commit provides a TAGS configuration can be entered with a default value