### PR TITLE
use raw fqdn as much as possible

### DIFF
--- a/route/router.go
+++ b/route/router.go
@@ -26,9 +26,9 @@ import (
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing-box/outbound"
 	"github.com/sagernet/sing-box/transport/fakeip"
-	"github.com/sagernet/sing-dns"
-	"github.com/sagernet/sing-tun"
-	"github.com/sagernet/sing-vmess"
+	dns "github.com/sagernet/sing-dns"
+	tun "github.com/sagernet/sing-tun"
+	vmess "github.com/sagernet/sing-vmess"
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
 	"github.com/sagernet/sing/common/bufio"
@@ -649,21 +649,27 @@ func (r *Router) RouteConnection(ctx context.Context, conn net.Conn, metadata ad
 		conn = deadline.NewConn(conn)
 	}
 
+	if metadata.Domain == "" && metadata.Destination.IsFqdn() {
+		metadata.Domain = metadata.Destination.Fqdn
+	}
+
 	if metadata.InboundOptions.SniffEnabled {
 		buffer := buf.NewPacket()
 		buffer.FullReset()
 		sniffMetadata, err := sniff.PeekStream(ctx, conn, buffer, time.Duration(metadata.InboundOptions.SniffTimeout), sniff.StreamDomainNameQuery, sniff.TLSClientHello, sniff.HTTPHost)
 		if sniffMetadata != nil {
 			metadata.Protocol = sniffMetadata.Protocol
-			metadata.Domain = sniffMetadata.Domain
-			if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
-				metadata.Destination = M.Socksaddr{
-					Fqdn: metadata.Domain,
-					Port: metadata.Destination.Port,
+			if metadata.Domain == "" {
+				metadata.Domain = sniffMetadata.Domain
+				if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
+					metadata.Destination = M.Socksaddr{
+						Fqdn: metadata.Domain,
+						Port: metadata.Destination.Port,
+					}
 				}
 			}
-			if metadata.Domain != "" {
-				r.logger.DebugContext(ctx, "sniffed protocol: ", metadata.Protocol, ", domain: ", metadata.Domain)
+			if sniffMetadata.Domain != "" {
+				r.logger.DebugContext(ctx, "sniffed protocol: ", metadata.Protocol, ", domain: ", sniffMetadata.Domain)
 			} else {
 				r.logger.DebugContext(ctx, "sniffed protocol: ", metadata.Protocol)
 			}
@@ -759,6 +765,10 @@ func (r *Router) RoutePacketConnection(ctx context.Context, conn N.PacketConn, m
 		conn = deadline.NewPacketConn(bufio.NewNetPacketConn(conn))
 	}*/
 
+	if metadata.Domain == "" && metadata.Destination.IsFqdn() {
+		metadata.Domain = metadata.Destination.Fqdn
+	}
+
 	if metadata.InboundOptions.SniffEnabled || metadata.Destination.Addr.IsUnspecified() {
 		buffer := buf.NewPacket()
 		buffer.FullReset()
@@ -774,11 +784,13 @@ func (r *Router) RoutePacketConnection(ctx context.Context, conn N.PacketConn, m
 			sniffMetadata, _ := sniff.PeekPacket(ctx, buffer.Bytes(), sniff.DomainNameQuery, sniff.QUICClientHello, sniff.STUNMessage)
 			if sniffMetadata != nil {
 				metadata.Protocol = sniffMetadata.Protocol
-				metadata.Domain = sniffMetadata.Domain
-				if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
-					metadata.Destination = M.Socksaddr{
-						Fqdn: metadata.Domain,
-						Port: metadata.Destination.Port,
+				if metadata.Domain == "" {
+					metadata.Domain = sniffMetadata.Domain
+					if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
+						metadata.Destination = M.Socksaddr{
+							Fqdn: metadata.Domain,
+							Port: metadata.Destination.Port,
+						}
 					}
 				}
 				if metadata.Domain != "" {


### PR DESCRIPTION
在目前的 `route` 过程中，当 `inbounds[each].sniff` 被设置为 `true`，`metadata.domain` 会被设置为 `sniffMetadata.Domain`。在这个过程之后，如果 `dns.reverse_mapping` 被设置为 `true`，且 `metadata.domain` 为空时，`metadata.domain` 会被设置为 `dnsReverseMapping` 里的解析结果缓存。在之后的域名规则匹配过程中，只有 `metadata.domain` 为空时，才会匹配 `metadata.Destination.Fqdn`，这是非常糟糕的。当我们收到一个 fqdn 入站时，我们的域名规则匹配只应该使用该 fqdn。同时，当我们收到一个 fqdn 入站时，`sniff_override` 过程变的毫无意义，甚至会破坏入站数据，所以我们应该仍然保持原始入站数据，哪怕 `inbounds[each].sniff_override` 被设置为 `true`。