### PR TITLE
Add ipondemand and `skip_resolve`

### DIFF
--- a/adapter/router.go
+++ b/adapter/router.go
@@ -68,6 +68,8 @@ type Rule interface {
 	Type() string
 	UpdateGeosite() error
 	Match(metadata *InboundContext) bool
+	SkipResolve() bool
+	UseIPRule() bool
 	Outbound() string
 	String() string
 }

--- a/docs/configuration/route/rule.md
+++ b/docs/configuration/route/rule.md
@@ -84,6 +84,7 @@
         ],
         "clash_mode": "direct",
         "invert": false,
+        "skip_resolve": false,
         "outbound": "direct"
       },
       {
@@ -91,6 +92,7 @@
         "mode": "and",
         "rules": [],
         "invert": false,
+        "skip_resolve": false,
         "outbound": "direct"
       }
     ]
@@ -231,6 +233,10 @@ Match Clash mode.
 #### invert
 
 Invert match result.
+
+#### skip_resolve
+
+Skip resolving domain.
 
 #### outbound
 

--- a/docs/configuration/route/rule.zh.md
+++ b/docs/configuration/route/rule.zh.md
@@ -82,6 +82,7 @@
         ],
         "clash_mode": "direct",
         "invert": false,
+        "skip_resolve": false,
         "outbound": "direct"
       },
       {
@@ -89,6 +90,7 @@
         "mode": "and",
         "rules": [],
         "invert": false,
+        "skip_resolve": false,
         "outbound": "direct"
       }
     ]
@@ -229,6 +231,10 @@
 #### invert
 
 反选匹配结果。
+
+#### skip_resolve
+
+跳过域名解析。
 
 #### outbound
 

--- a/option/rule.go
+++ b/option/rule.go
@@ -79,6 +79,7 @@ type DefaultRule struct {
 	UserID          Listable[int32]  `json:"user_id,omitempty"`
 	ClashMode       string           `json:"clash_mode,omitempty"`
 	Invert          bool             `json:"invert,omitempty"`
+	SkipResolve     bool             `json:"skip_resolve,omitempty"`
 	Outbound        string           `json:"outbound,omitempty"`
 }
 
@@ -90,10 +91,11 @@ func (r DefaultRule) IsValid() bool {
 }
 
 type LogicalRule struct {
-	Mode     string        `json:"mode"`
-	Rules    []DefaultRule `json:"rules,omitempty"`
-	Invert   bool          `json:"invert,omitempty"`
-	Outbound string        `json:"outbound,omitempty"`
+	Mode        string        `json:"mode"`
+	Rules       []DefaultRule `json:"rules,omitempty"`
+	Invert      bool          `json:"invert,omitempty"`
+	SkipResolve bool          `json:"skip_resolve,omitempty"`
+	Outbound    string        `json:"outbound,omitempty"`
 }
 
 func (r LogicalRule) IsValid() bool {

--- a/route/rule_abstract.go
+++ b/route/rule_abstract.go
@@ -17,11 +17,21 @@ type abstractDefaultRule struct {
 	destinationPortItems    []RuleItem
 	allItems                []RuleItem
 	invert                  bool
+	skipResolve             bool
 	outbound                string
+	useIPRule               bool
 }
 
 func (r *abstractDefaultRule) Type() string {
 	return C.RuleTypeDefault
+}
+
+func (r *abstractDefaultRule) SkipResolve() bool {
+	return r.skipResolve
+}
+
+func (r *abstractDefaultRule) UseIPRule() bool {
+	return r.useIPRule
 }
 
 func (r *abstractDefaultRule) Start() error {
@@ -135,14 +145,24 @@ func (r *abstractDefaultRule) String() string {
 }
 
 type abstractLogicalRule struct {
-	rules    []adapter.Rule
-	mode     string
-	invert   bool
-	outbound string
+	rules       []adapter.Rule
+	mode        string
+	invert      bool
+	skipResolve bool
+	outbound    string
+	useIPRule   bool
 }
 
 func (r *abstractLogicalRule) Type() string {
 	return C.RuleTypeLogical
+}
+
+func (r *abstractLogicalRule) SkipResolve() bool {
+	return r.skipResolve
+}
+
+func (r *abstractLogicalRule) UseIPRule() bool {
+	return r.useIPRule
 }
 
 func (r *abstractLogicalRule) UpdateGeosite() error {


### PR DESCRIPTION
我们知道，当流量入站并构建好 `metadata` 之后，我们会依据 `metadata` 内容对 `router.rules` 进行匹配。在这个过程中，当 `metadata.Destination` 为 fqdn 且没有设置 `inbound.domain_strategy` 时，我们并不会对其进行解析并且拿到其对应的 ip，使得我们也无法用它匹配 `ipcidr` 和 `geoip` 规则，这两个规则将被彻底忽略。而当我们设置 `inbound.domain_stategy` 为任意合法值之后，fqdn 将会被解析成 ip，可以匹配 `ipcidr` 和 `geoip` 规则，但同样的，我们也会在 `outbound` 过程中丢弃 fqdn，直接将 ip 解析结果发送到远端。

考虑以下情况：

当 dns 模块使用 `fakeip` 时，我们收到一个 `fakeip` 入站，在 `route` 模块中，我们将 `metadata.Destination` 还原成了 `fakeip` 缓存中的 fqdn，并用其对 `router.rules` 进行匹配。
很显然，域名集不会是尽善尽美的，我们需要使用 `geoip:cn` 进行兜底保证正确分流，当一个国内域名未被收录在域名集之中，我们显然也无法通过域名规则将此域名排除在 fakeip 之外而获取到真实解析，我们也将无法正确匹配 `geoip:cn` 规则使其分流到国内出口。

此 commit 为 sing-box 添加了 ray 系的 `ipondemand` 能力，可完美规避此问题。

同时针对只想匹配 ip 入站而不希望 fqdn 入站被解析的规则，添加了 `skip_resolve` 参数，类似 clash 规则里的 `no-resolve`。