### PR TITLE
fix: correctly set KDE system proxy

### DIFF
--- a/common/settings/proxy_linux.go
+++ b/common/settings/proxy_linux.go
@@ -71,7 +71,7 @@ func (p *LinuxSystemProxy) Enable() error {
 		}
 	}
 	if p.hasKWriteConfig5 {
-		err := p.runAsUser("kwriteconfig5", "--file", "kioslaverc", "--group", "'Proxy Settings'", "--key", "ProxyType", "1")
+		err := p.runAsUser("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", "1")
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func (p *LinuxSystemProxy) Enable() error {
 		if err != nil {
 			return err
 		}
-		err = p.runAsUser("kwriteconfig5", "--file", "kioslaverc", "--group", "'Proxy Settings'", "--key", "Authmode", "0")
+		err = p.runAsUser("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "Authmode", "0")
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func (p *LinuxSystemProxy) Disable() error {
 		}
 	}
 	if p.hasKWriteConfig5 {
-		err := p.runAsUser("kwriteconfig5", "--file", "kioslaverc", "--group", "'Proxy Settings'", "--key", "ProxyType", "0")
+		err := p.runAsUser("kwriteconfig5", "--file", "kioslaverc", "--group", "Proxy Settings", "--key", "ProxyType", "0")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently `set_system_proxy` on KDE5 does not work due to malformed command (there are extra quotes in the call). This PR fixes the issue.