### PR TITLE
documentation: tips on SOCKS UDP

### DIFF
--- a/docs/configuration/inbound/socks.md
+++ b/docs/configuration/inbound/socks.md
@@ -22,6 +22,10 @@
 
 See [Listen Fields](/configuration/shared/listen) for details.
 
+!!! error ""
+
+    The support for UDP follows [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928), will use random available UDP ports, as opposed to other popular proxy programs which use [fixed UDP port](https://github.com/v2fly/v2fly-github-io/issues/104).
+
 ### Fields
 
 #### users

--- a/docs/configuration/inbound/socks.zh.md
+++ b/docs/configuration/inbound/socks.zh.md
@@ -22,6 +22,10 @@
 
 参阅 [监听字段](/zh/configuration/shared/listen/)。
 
+!!! error ""
+
+    对于 UDP 的支持遵照 [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928)，将使用随机可用的 UDP 端口，而非其他一些流行代理程序中使用的[固定 UDP 端口](https://github.com/v2fly/v2fly-github-io/issues/104)。
+
 ### 字段
 
 #### users


### PR DESCRIPTION
Tips on the difference of SOCKS UDP support between sing-box and other popular proxy programs

对于 UDP 的支持遵照 [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928)，将使用随机可用的 UDP 端口，而非其他一些流行代理程序中使用的[固定 UDP 端口](https://github.com/v2fly/v2fly-github-io/issues/104)。

The support for UDP follows [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928), will use random available UDP ports, as opposed to other popular proxy programs which use [fixed UDP port](https://github.com/v2fly/v2fly-github-io/issues/104).
