### PR TITLE
docs: describe domain resolution behavior in routing more accurately

### DIFF
--- a/docs/configuration/route/rule.md
+++ b/docs/configuration/route/rule.md
@@ -114,6 +114,10 @@
     (`source_port` || `source_port_range`) &&  
     `other fields`
 
+!!! note ""
+    
+    Domain name will not be resolved to IP when doing rule matching. If you need resolution, see `domain_strategy` in [Listen Fields](/configuration/shared/listen/#domain_strategy).
+
 #### inbound
 
 Tags of [Inbound](/configuration/inbound).

--- a/docs/configuration/route/rule.zh.md
+++ b/docs/configuration/route/rule.zh.md
@@ -112,6 +112,10 @@
     (`source_port` || `source_port_range`) &&  
     `other fields`
 
+!!! note ""
+
+    进行规则匹配时不会将域名解析为 IP。如需解析，请参阅 [监听字段](/zh/configuration/shared/listen/#domain_strategy) 中的 `domain_strategy`。
+
 #### inbound
 
 [入站](/zh/configuration/inbound) 标签。

--- a/docs/configuration/shared/listen.md
+++ b/docs/configuration/shared/listen.md
@@ -78,7 +78,7 @@ Timeout for sniffing.
 
 One of `prefer_ipv4` `prefer_ipv6` `ipv4_only` `ipv6_only`.
 
-If set, the requested domain name will be resolved to IP before routing.
+If set, the requested domain name will be resolved to IP before routing, both domain name and IP will be used in route matching.
 
 If `sniff_override_destination` is in effect, its value will be taken as a fallback.
 

--- a/docs/configuration/shared/listen.zh.md
+++ b/docs/configuration/shared/listen.zh.md
@@ -79,7 +79,7 @@
 
 可选值： `prefer_ipv4` `prefer_ipv6` `ipv4_only` `ipv6_only`。
 
-如果设置，请求的域名将在路由之前解析为 IP。
+如果设置，请求的域名将在路由之前解析为 IP，路由匹配时会同时匹配域名和 IP。
 
 如果 `sniff_override_destination` 生效，它的值将作为后备。
 


### PR DESCRIPTION
Describe domain resolution behavior in routing more accurately, to avoid misconfiguration caused by misunderstanding.