### PR TITLE
Fix response fakeip when routing

### DIFF
--- a/adapter/inbound.go
+++ b/adapter/inbound.go
@@ -47,6 +47,7 @@ type InboundContext struct {
 	GeoIPCode            string
 	ProcessInfo          *process.Info
 	FakeIP               bool
+	IsFromDnsOutbound    bool
 
 	// dns cache
 

--- a/outbound/dns.go
+++ b/outbound/dns.go
@@ -77,6 +77,7 @@ func (d *DNS) handleConnection(ctx context.Context, conn net.Conn, metadata adap
 		return err
 	}
 	metadataInQuery := metadata
+	metadataInQuery.IsFromDnsOutbound = true
 	go func() error {
 		response, err := d.router.Exchange(adapter.WithContext(ctx, &metadataInQuery), &message)
 		if err != nil {
@@ -157,6 +158,7 @@ func (d *DNS) NewPacketConnection(ctx context.Context, conn N.PacketConn, metada
 				timeout.Update()
 			}
 			metadataInQuery := metadata
+			metadataInQuery.IsFromDnsOutbound = true
 			go func() error {
 				response, err := d.router.Exchange(adapter.WithContext(ctx, &metadataInQuery), &message)
 				if err != nil {
@@ -235,6 +237,7 @@ func (d *DNS) newPacketConnection(ctx context.Context, conn N.PacketConn, readWa
 				timeout.Update()
 			}
 			metadataInQuery := metadata
+			metadataInQuery.IsFromDnsOutbound = true
 			go func() error {
 				response, err := d.router.Exchange(adapter.WithContext(ctx, &metadataInQuery), &message)
 				if err != nil {

--- a/route/router_dns.go
+++ b/route/router_dns.go
@@ -50,7 +50,7 @@ func (r *Router) matchDNS(ctx context.Context) (context.Context, dns.Transport, 
 				r.dnsLogger.ErrorContext(ctx, "transport not found: ", detour)
 				continue
 			}
-			if _, isFakeIP := transport.(adapter.FakeIPTransport); isFakeIP && metadata.FakeIP {
+			if _, isFakeIP := transport.(adapter.FakeIPTransport); isFakeIP && !metadata.IsFromDnsOutbound {
 				continue
 			}
 			r.dnsLogger.DebugContext(ctx, "match[", i, "] ", rule.String(), " => ", detour)


### PR DESCRIPTION
FakeIP 通过回应 fakeip range 里的地址来记录 dns 请求的 fqdn，在减少 dns 查询响应时间的同时，方便在 route 阶段还原出 fqdn。

现阶段的 dns 规则匹配中只有在遇到 `metadata.fakeip` 为 `true` 时才会跳过指向 fakeip 服务器的规则，很显然，这么做是有缺陷的。

我们假设以下情况：

1. 启用除 tproxy/tun 以外的，可以接收 destination 为 fqdn 的入站，例如：socks5 / shadowsocks / vmess etc.

2. 设置 `inbounds[i].domain_strategy` 为 `true`

3. 将指向 fakeip 服务器的匹配规则前置（假设入站 fqdn 均可匹配到此规则）

很显然，在此情况下，sing-box 在 route 模块中收到了客户端传递而来的 fqdn，同时触发 dns 解析，此时我们无法获取到 realip，而是通过 fakeip 服务器的响应拿到了 fakeip，那么，我们完全无法与正确的对端服务器进行交互。

此 commit 修改如下：

1. 为 `InboundContext` 增加一个名为 `IsFromDnsOutbound` 的 bool 类型的值

2. 在 `outobund/dns.go` 中将 `metadataInQuery` 的 `IsFromDnsOutbound` 设置为 `true`

3. 修改 dns rule 匹配规则，将 `isFakeIP && metadata.FakeIP` 改为 `isFakeIP && !metadata.IsFromDnsOutbound`

至此，我们仅对 route 过程中劫持而来的 dns 请求下发 fakeip，而不会影响其他任意形式传入 fqdn 的正确解析，即在前文所假定情形下依然可以正确解析出目标服务器 ip 地址。