### PR TITLE
Fix geoip download bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/sagernet/gvisor v0.0.0-20230930141345-5fef6f2e17ab
 	github.com/sagernet/quic-go v0.0.0-20231008035953-32727fef9460
 	github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691
-	github.com/sagernet/sing v0.2.16-0.20231028125948-afcc9cb766c2
+	github.com/sagernet/sing v0.2.16-0.20231105072849-64e91d772616
 	github.com/sagernet/sing-dns v0.1.10
 	github.com/sagernet/sing-mux v0.1.4-0.20231105044304-ae2745a33479
 	github.com/sagernet/sing-quic v0.1.3-0.20231026034240-fa3d997246b6

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691 h1:5Th31OC6yj8byL
 github.com/sagernet/reality v0.0.0-20230406110435-ee17307e7691/go.mod h1:B8lp4WkQ1PwNnrVMM6KyuFR20pU8jYBD+A4EhJovEXU=
 github.com/sagernet/sing v0.0.0-20220817130738-ce854cda8522/go.mod h1:QVsS5L/ZA2Q5UhQwLrn0Trw+msNd/NPGEhBKR/ioWiY=
 github.com/sagernet/sing v0.1.8/go.mod h1:jt1w2u7lJQFFSGLiRrRIs5YWmx4kAPfWuOejuDW9qMk=
-github.com/sagernet/sing v0.2.16-0.20231028125948-afcc9cb766c2 h1:PW18IgRodvppd09d4mewYM3Hedu3PtFERN8yOqkTVk0=
-github.com/sagernet/sing v0.2.16-0.20231028125948-afcc9cb766c2/go.mod h1:AhNEHu0GXrpqkuzvTwvC8+j2cQUU/dh+zLEmq4C99pg=
+github.com/sagernet/sing v0.2.16-0.20231105072849-64e91d772616 h1:zIm6f7NQR8zhkAaoCIe8sL9Rp3HAkfoF+FGb4XEN3SY=
+github.com/sagernet/sing v0.2.16-0.20231105072849-64e91d772616/go.mod h1:AhNEHu0GXrpqkuzvTwvC8+j2cQUU/dh+zLEmq4C99pg=
 github.com/sagernet/sing-dns v0.1.10 h1:iIU7nRBlUYj+fF2TaktGIvRiTFFrHwSMedLQsvlTZCI=
 github.com/sagernet/sing-dns v0.1.10/go.mod h1:vtUimtf7Nq9EdvD5WTpfCr69KL1M7bcgOVKiYBiAY/c=
 github.com/sagernet/sing-mux v0.1.4-0.20231105044304-ae2745a33479 h1:h6ANTA5wbP5BSqbjOT7s1OKLZgdsLqiXO564KQqY2i4=

--- a/route/router_geo_resources.go
+++ b/route/router_geo_resources.go
@@ -157,12 +157,6 @@ func (r *Router) downloadGeoIPDatabase(savePath string) error {
 		filemanager.MkdirAll(r.ctx, parentDir, 0o755)
 	}
 
-	saveFile, err := filemanager.Create(r.ctx, savePath)
-	if err != nil {
-		return E.Cause(err, "open output file: ", downloadURL)
-	}
-	defer saveFile.Close()
-
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			ForceAttemptHTTP2:   true,
@@ -182,6 +176,13 @@ func (r *Router) downloadGeoIPDatabase(savePath string) error {
 		return err
 	}
 	defer response.Body.Close()
+
+	saveFile, err := filemanager.Create(r.ctx, savePath)
+	if err != nil {
+		return E.Cause(err, "open output file: ", downloadURL)
+	}
+	defer saveFile.Close()
+	
 	_, err = io.Copy(saveFile, response.Body)
 	return err
 }
@@ -209,12 +210,6 @@ func (r *Router) downloadGeositeDatabase(savePath string) error {
 		filemanager.MkdirAll(r.ctx, parentDir, 0o755)
 	}
 
-	saveFile, err := filemanager.Create(r.ctx, savePath)
-	if err != nil {
-		return E.Cause(err, "open output file: ", downloadURL)
-	}
-	defer saveFile.Close()
-
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			ForceAttemptHTTP2:   true,
@@ -234,6 +229,13 @@ func (r *Router) downloadGeositeDatabase(savePath string) error {
 		return err
 	}
 	defer response.Body.Close()
+
+	saveFile, err := filemanager.Create(r.ctx, savePath)
+	if err != nil {
+		return E.Cause(err, "open output file: ", downloadURL)
+	}
+	defer saveFile.Close()
+	
 	_, err = io.Copy(saveFile, response.Body)
 	return err
 }

--- a/route/router_geo_resources.go
+++ b/route/router_geo_resources.go
@@ -181,9 +181,11 @@ func (r *Router) downloadGeoIPDatabase(savePath string) error {
 	if err != nil {
 		return E.Cause(err, "open output file: ", downloadURL)
 	}
-	defer saveFile.Close()
-	
 	_, err = io.Copy(saveFile, response.Body)
+	saveFile.Close()
+	if err != nil {
+		filemanager.Remove(r.ctx, savePath)
+	}
 	return err
 }
 
@@ -234,9 +236,11 @@ func (r *Router) downloadGeositeDatabase(savePath string) error {
 	if err != nil {
 		return E.Cause(err, "open output file: ", downloadURL)
 	}
-	defer saveFile.Close()
-	
 	_, err = io.Copy(saveFile, response.Body)
+	saveFile.Close()
+	if err != nil {
+		filemanager.Remove(r.ctx, savePath)
+	}
 	return err
 }
 


### PR DESCRIPTION
This is how sing-box tries to handle downloading geoip.db file 

Senari 1
if the geoip.db file path exists then it tries to open the file and parse it. if file is empty or has invalid content it return error invalid MaxMind DB otherwise it parse the file successfully

Senari 2
if the geoip.db file path does not exist first it creates the geoip.db file but with empty content and then it tries to download the geoip.db file.if file downloaded successfully it copy the response to the to the geoip.db file but if download gets an error it return error and the geoip.db file remains with empty content and zero size so in the next run we have Senari 1 because the file path exists but we get an error because the file is empty.

Solution
so i change the order of create file to fix that problem the file created only after the file  successfully downloaded.