### PR TITLE
fix: html tag <details> needs at least one line to seperate from markdown code-fence so that the style can be parsed properly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,6 +46,7 @@ body:
       description: If you are using the original command line program, please provide the output of the `sing-box version` command.
       value: |-
         <details>
+
         ```console
         # Replace this line with the output
         ```
@@ -71,6 +72,7 @@ body:
         For the Android client, please check the `/sdcard/Android/data/io.nekohasekai.sfa/files/stderr.log` file for crash logs.
       value: |-
         <details>
+        
         ```console
         # Replace this line with logs
         ```

--- a/.github/ISSUE_TEMPLATE/bug_report_zh.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_zh.yml
@@ -46,6 +46,7 @@ body:
       description: 如果您使用原始命令行程序，请提供 `sing-box version` 命令的输出。
       value: |-
         <details>
+
         ```console
         # 使用输出内容覆盖此行
         ```
@@ -71,6 +72,7 @@ body:
         对于 Android 图形客户端程序，请检查 `/sdcard/Android/data/io.nekohasekai.sfa/files/stderr.log` 文件以导出崩溃日志。
       value: |-
         <details>
+        
         ```console
         # 使用日志内容覆盖此行
         ```


### PR DESCRIPTION
I have seen many open-issue styles broken because the `<details>` tag requires at least one line to separate from the markdown code-fence.

e.g.
![image](https://github.com/SagerNet/sing-box/assets/10484271/4ed1640c-0825-40ef-b4b2-3b4bf042395e)


This pull request fixes the issue template style.