### PR TITLE
use the correct context to handle mux stream

### DIFF
--- a/transport/trojan/mux.go
+++ b/transport/trojan/mux.go
@@ -17,7 +17,7 @@ func HandleMuxConnection(ctx context.Context, conn net.Conn, metadata M.Metadata
 		return err
 	}
 	var group task.Group
-	group.Append0(func(ctx context.Context) error {
+	group.Append0(func(newCtx context.Context) error {
 		var stream net.Conn
 		for {
 			stream, err = session.AcceptStream()


### PR DESCRIPTION
修复Trojan Go多路复用不能用的问题