### PR TITLE
fix not closing outConn

### DIFF
--- a/outbound/default.go
+++ b/outbound/default.go
@@ -71,6 +71,7 @@ func NewConnection(ctx context.Context, this N.Dialer, conn net.Conn, metadata a
 	}
 	err = N.ReportHandshakeSuccess(conn)
 	if err != nil {
+		outConn.Close()
 		return err
 	}
 	return CopyEarlyConn(ctx, conn, outConn)
@@ -97,6 +98,7 @@ func NewDirectConnection(ctx context.Context, router adapter.Router, this N.Dial
 	}
 	err = N.ReportHandshakeSuccess(conn)
 	if err != nil {
+		outConn.Close()
 		return err
 	}
 	return CopyEarlyConn(ctx, conn, outConn)
@@ -117,6 +119,7 @@ func NewPacketConnection(ctx context.Context, this N.Dialer, conn N.PacketConn, 
 	}
 	err = N.ReportHandshakeSuccess(conn)
 	if err != nil {
+		outConn.Close()
 		return err
 	}
 	if destinationAddress.IsValid() {
@@ -164,6 +167,7 @@ func NewDirectPacketConnection(ctx context.Context, router adapter.Router, this 
 	}
 	err = N.ReportHandshakeSuccess(conn)
 	if err != nil {
+		outConn.Close()
 		return err
 	}
 	if destinationAddress.IsValid() {
@@ -186,6 +190,7 @@ func NewDirectPacketConnection(ctx context.Context, router adapter.Router, this 
 }
 
 func CopyEarlyConn(ctx context.Context, conn net.Conn, serverConn net.Conn) error {
+	defer serverConn.Close()
 	if cachedReader, isCached := conn.(N.CachedReader); isCached {
 		payload := cachedReader.ReadCached()
 		if payload != nil && !payload.IsEmpty() {


### PR DESCRIPTION
In the `NewDirectConnection` and `NewConnection` functions in case informing a successful handshake fails we never close the outConn anywhere in the code. Same goes for `NewDirectPacketConnection` and `NewPacketConnection` . Also in the `CopyEarlyConn` function, in case any error occurs and we return early, the serverConn will never get closed by us, which is wrong. By deferring its close, if the process has gone normally it will be closed in `CopyConn` and calling close again will have no effect, if the process of `CopyEarlyConn` has exited prematurely then we will close the serverConn as we should.
we could also simply defer closing the outConn after we confirmed that dial has been successful, but I believe calling close on necessary spots is a better practice here.