### PR TITLE
Fix cannot get correct version in ghcr.io image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
           target: dist
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           tags: |
             ${{ steps.tag.outputs.latest }}
             ${{ steps.tag.outputs.versioned }}


### PR DESCRIPTION
When we run `docker run ghcr.io/sagernet/sing-box:latest version`
```terminal
$ docker run ghcr.io/sagernet/sing-box:latest version
sing-box version unknown

Environment: go1.21.4 linux/amd64
Tags: with_gvisor,with_quic,with_dhcp,with_wireguard,with_ech,with_utls,with_reality_server,with_clash_api,with_acme
CGO: disabled
```
Cannot get correct version

We can keep the .git folder at compile time to get the correct version
See also: https://github.com/docker/build-push-action/issues/378