### PR TITLE
Change Tor man page link to official documentation

### DIFF
--- a/docs/configuration/outbound/tor.md
+++ b/docs/configuration/outbound/tor.md
@@ -44,7 +44,7 @@ Each start will be very slow if not specified.
 
 Map of torrc options.
 
-See [tor(1)](https://linux.die.net/man/1/tor) for details.
+See [tor manual](https://2019.www.torproject.org/docs/tor-manual.html.en) for details.
 
 ### Dial Fields
 

--- a/docs/configuration/outbound/tor.zh.md
+++ b/docs/configuration/outbound/tor.zh.md
@@ -44,7 +44,7 @@ Tor 的数据目录。
 
 torrc 参数表。
 
-参阅 [tor(1)](https://linux.die.net/man/1/tor)。
+参阅 [tor 手册](https://2019.www.torproject.org/docs/tor-manual.html.en)。
 
 ### 拨号字段
 


### PR DESCRIPTION
Some configuration options are missing in the manpage, e.g. `ConnectionPadding`, this pr change manpage to official documentation.