### PR TITLE
Remove `PROCESS_NAME_NATIVE` dwFlag in process query output

### DIFF
--- a/common/process/searcher_windows.go
+++ b/common/process/searcher_windows.go
@@ -223,7 +223,7 @@ func getExecPathFromPID(pid uint32) (string, error) {
 	r1, _, err := syscall.SyscallN(
 		procQueryFullProcessImageNameW.Addr(),
 		uintptr(h),
-		uintptr(1),
+		uintptr(0),
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(unsafe.Pointer(&size)),
 	)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,21 @@
 icon: material/arrange-bring-forward
 ---
 
+## 1.9.0
+
+!!! warning "Unstable"
+
+    This version is still under development, and the following migration guide may be changed in the future.
+
+### `process_path` format update on Windows
+
+The `process_path` rule of sing-box is inherited from Clash,
+the original code uses the local system's path format (e.g. `\Device\HarddiskVolume1\folder\program.exe`),
+but when the device has multiple disks, the HarddiskVolume serial number is not stable.
+
+sing-box 1.9.0 make QueryFullProcessImageNameW output a Win32 path (such as `C:\folder\program.exe`),
+which will disrupt the existing `process_path` use cases in Windows.
+
 ## 1.8.0
 
 ### :material-close-box: Migrate cache file from Clash API to independent options

--- a/docs/migration.zh.md
+++ b/docs/migration.zh.md
@@ -2,6 +2,21 @@
 icon: material/arrange-bring-forward
 ---
 
+## 1.9.0
+
+!!! warning "不稳定的"
+
+    该版本仍在开发中，迁移指南可能将在未来更改。
+
+### 对 Windows 上 `process_path` 格式的更新
+
+sing-box 的 `process_path` 规则继承自Clash，
+原始代码使用本地系统的路径格式（例如 `\Device\HarddiskVolume1\folder\program.exe`），
+但是当设备有多个硬盘时，该 HarddiskVolume 系列号并不稳定。
+
+sing-box 1.9.0 使 QueryFullProcessImageNameW 输出 Win32 路径（如 `C:\folder\program.exe`），
+这将会破坏现有的 Windows `process_path` 用例。
+
 ## 1.8.0
 
 ### :material-close-box: 将缓存文件从 Clash API 迁移到独立选项


### PR DESCRIPTION
The `process_path` rule of sing-box is inherited from Clash,
the original code uses the local system's path format (e.g. `\Device\HarddiskVolume1\folder\program.exe`),
but when the device has multiple disks, the HarddiskVolume serial number is not stable.

This change make QueryFullProcessImageNameW output a Win32 path (such as `C:\folder\program.exe`),
which will disrupt the existing `process_path` use cases in Windows.

TODO: 

- [x] Update documentation to add behavior description and migration instructions for `process_path`