### PR TITLE
Add network-online.target in .service files

### DIFF
--- a/release/config/sing-box.service
+++ b/release/config/sing-box.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=sing-box service
 Documentation=https://sing-box.sagernet.org
-After=network.target nss-lookup.target
+After=network.target nss-lookup.target network-online.target
 
 [Service]
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH

--- a/release/config/sing-box@.service
+++ b/release/config/sing-box@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=sing-box service
 Documentation=https://sing-box.sagernet.org
-After=network.target nss-lookup.target
+After=network.target nss-lookup.target network-online.target
 
 [Service]
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH

--- a/release/local/sing-box.service
+++ b/release/local/sing-box.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=sing-box service
 Documentation=https://sing-box.sagernet.org
-After=network.target nss-lookup.target
+After=network.target nss-lookup.target network-online.target
 
 [Service]
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH


### PR DESCRIPTION
This helps the daemon work better on IoT devices like RaspberryPi.
According to systemd's documentation,`network.target` means there has already been a network manager started, but the network may not be "up". On most PCs this does not matter because the network will turn to "up" almost immediately. The IoT devices' network interface may not be set up quickly enough, so they may meet that the sing-box daemon is started before network is ready, which results that sing-box cannot find a working route. The workaround of this is restarting sing-box daemon but it absolutely is not the perfect solution.
As `network-online.target` must be triggered by network manager after you configured it, I keep `network.target` so there will be no change to those who do not enabled proper trigger service like `NetworkManager-wait-online.service`.

See also: https://systemd.io/NETWORK_ONLINE/