### PR TITLE
Fix rule description header of domain_suffix

### DIFF
--- a/route/rule_item_domain.go
+++ b/route/rule_item_domain.go
@@ -30,11 +30,11 @@ func NewDomainItem(domains []string, domainSuffixes []string) *DomainItem {
 			description += " "
 		}
 		if dsLen == 1 {
-			description += "domainSuffix=" + domainSuffixes[0]
+			description += "domain_suffix=" + domainSuffixes[0]
 		} else if dsLen > 3 {
-			description += "domainSuffix=[" + strings.Join(domainSuffixes[:3], " ") + "...]"
+			description += "domain_suffix=[" + strings.Join(domainSuffixes[:3], " ") + "...]"
 		} else {
-			description += "domainSuffix=[" + strings.Join(domainSuffixes, " ") + "]"
+			description += "domain_suffix=[" + strings.Join(domainSuffixes, " ") + "]"
 		}
 	}
 	return &DomainItem{


### PR DESCRIPTION
I read other rule_item_xxx.go files, they are all snake case. This description is showed on dashboard like yacd.