### PR TITLE
Fix mobile build on windows

### DIFF
--- a/cmd/internal/build_shared/sdk.go
+++ b/cmd/internal/build_shared/sdk.go
@@ -85,8 +85,15 @@ var GoBinPath string
 
 func FindMobile() {
 	goBin := filepath.Join(build.Default.GOPATH, "bin")
-	if !rw.FileExists(goBin + "/" + "gobind") {
-		log.Fatal("missing gomobile installation")
+	
+	if runtime.GOOS == "windows" {
+		if !rw.FileExists(goBin + "/" + "gobind.exe") {
+			log.Fatal("missing gomobile.exe installation")
+		}
+	} else {
+		if !rw.FileExists(goBin + "/" + "gobind") {
+			log.Fatal("missing gomobile installation")
+		}
 	}
 	GoBinPath = goBin
 }


### PR DESCRIPTION
gobind executable name is not exactly `gobind` on windows it's `gobind.exe`