### PR TITLE
Fix Compress UDP DNS response instead of truncate

### DIFF
--- a/outbound/dns.go
+++ b/outbound/dns.go
@@ -241,9 +241,11 @@ func (d *DNS) newPacketConnection(ctx context.Context, conn N.PacketConn, readWa
 					return err
 				}
 				timeout.Update()
-				response = truncateDNSMessage(response, 512) // TODO: add an option to custom UDP buffer size
 				responseBuffer := buf.NewSize(dns.FixedPacketSize)
 				responseBuffer.Resize(1024, 0)
+				if response.Len() > 512 {
+					response.Compress = true // TODO: add an option to compress UDP
+				}
 				n, err := response.PackBuffer(responseBuffer.FreeBytes())
 				if err != nil {
 					cancel(err)
@@ -263,22 +265,4 @@ func (d *DNS) newPacketConnection(ctx context.Context, conn N.PacketConn, readWa
 		conn.Close()
 	})
 	return group.Run(fastClose)
-}
-
-func truncateDNSMessage(response *mDNS.Msg, maxLen int) *mDNS.Msg {
-	responseLen := response.Len()
-	if responseLen <= maxLen {
-		return response
-	}
-	response = response.Copy()
-	for len(response.Answer) > 0 && responseLen > maxLen {
-		response.Answer = response.Answer[:len(response.Answer)-1]
-		response.Truncated = true
-		responseLen = response.Len()
-	}
-	if responseLen > maxLen {
-		response.Ns = nil
-		response.Extra = nil
-	}
-	return response
 }


### PR DESCRIPTION
在 [17aebc5](https://github.com/SagerNet/sing-box/commit/17aebc56c1b72696aa379a4806a6b73eb4fa3f85) 修复UDP DNS响应体过长导致无法解析的问题后，出现 api.aliyundrive.com 因截取导致 ip 信息丢失的问题，经抓包分析发现可以使用压缩选项来解决这两类域名问题

```sh
# 1.8.5
nslookup api.aliyundrive.com 192.168.2.179:1053
Server:         192.168.2.179:1053
Address:        192.168.2.179:1053

Non-authoritative answer:

Non-authoritative answer:
api.aliyundrive.com     canonical name = beijing.tfe.alibaba-clould.alibabacorp.com
beijing.tfe.alibaba-clould.alibabacorp.com      canonical name = beijing.tfe.alibaba-clould.alibabacorp.com.gds.alibabadns.com
beijing.tfe.alibaba-clould.alibabacorp.com.gds.alibabadns.com   canonical name = bj-static.tfe.alibaba-clould.alibabacorp.com
bj-static.tfe.alibaba-clould.alibabacorp.com    canonical name = bj-static.tfe.alibaba-clould.alibabacorp.com.gds.alibabadns.com
```

第三方上游DNS服务器返回压缩DNS响应体
![image](https://github.com/SagerNet/sing-box/assets/15168529/ff3e6e7b-46d9-4b88-bedd-85385f0de5a9)
经sing-box DNS服务器返回未压缩DNS响应体
![image](https://github.com/SagerNet/sing-box/assets/15168529/e48d894a-b88f-4e64-8df4-4c83f9136fea)
