### PR TITLE
remove additional close in command server

### DIFF
--- a/experimental/libbox/command_clash_mode.go
+++ b/experimental/libbox/command_clash_mode.go
@@ -30,7 +30,6 @@ func (c *CommandClient) SetClashMode(newMode string) error {
 }
 
 func (s *CommandServer) handleSetClashMode(conn net.Conn) error {
-	defer conn.Close()
 	newMode, err := rw.ReadVString(conn)
 	if err != nil {
 		return err
@@ -61,7 +60,6 @@ func (c *CommandClient) handleModeConn(conn net.Conn) {
 }
 
 func (s *CommandServer) handleModeConn(conn net.Conn) error {
-	defer conn.Close()
 	ctx := connKeepAlive(conn)
 	for s.service == nil {
 		select {
@@ -73,7 +71,6 @@ func (s *CommandServer) handleModeConn(conn net.Conn) error {
 	}
 	clashServer := s.service.instance.Router().ClashServer()
 	if clashServer == nil {
-		defer conn.Close()
 		return binary.Write(conn, binary.BigEndian, uint16(0))
 	}
 	err := writeClashModeList(conn, clashServer)

--- a/experimental/libbox/command_group.go
+++ b/experimental/libbox/command_group.go
@@ -58,7 +58,6 @@ func (c *CommandClient) handleGroupConn(conn net.Conn) {
 }
 
 func (s *CommandServer) handleGroupConn(conn net.Conn) error {
-	defer conn.Close()
 	ctx := connKeepAlive(conn)
 	for {
 		service := s.service
@@ -274,7 +273,6 @@ func (c *CommandClient) SetGroupExpand(groupTag string, isExpand bool) error {
 }
 
 func (s *CommandServer) handleSetGroupExpand(conn net.Conn) error {
-	defer conn.Close()
 	groupTag, err := rw.ReadVString(conn)
 	if err != nil {
 		return err

--- a/experimental/libbox/command_select.go
+++ b/experimental/libbox/command_select.go
@@ -31,7 +31,6 @@ func (c *CommandClient) SelectOutbound(groupTag string, outboundTag string) erro
 }
 
 func (s *CommandServer) handleSelectOutbound(conn net.Conn) error {
-	defer conn.Close()
 	groupTag, err := rw.ReadVString(conn)
 	if err != nil {
 		return err

--- a/experimental/libbox/command_system_proxy.go
+++ b/experimental/libbox/command_system_proxy.go
@@ -35,7 +35,6 @@ func (c *CommandClient) GetSystemProxyStatus() (*SystemProxyStatus, error) {
 }
 
 func (s *CommandServer) handleGetSystemProxyStatus(conn net.Conn) error {
-	defer conn.Close()
 	status := s.handler.GetSystemProxyStatus()
 	err := binary.Write(conn, binary.BigEndian, status.Available)
 	if err != nil {
@@ -68,7 +67,6 @@ func (c *CommandClient) SetSystemProxyEnabled(isEnabled bool) error {
 }
 
 func (s *CommandServer) handleSetSystemProxyEnabled(conn net.Conn) error {
-	defer conn.Close()
 	var isEnabled bool
 	err := binary.Read(conn, binary.BigEndian, &isEnabled)
 	if err != nil {

--- a/experimental/libbox/command_urltest.go
+++ b/experimental/libbox/command_urltest.go
@@ -33,7 +33,6 @@ func (c *CommandClient) URLTest(groupTag string) error {
 }
 
 func (s *CommandServer) handleURLTest(conn net.Conn) error {
-	defer conn.Close()
 	groupTag, err := rw.ReadVString(conn)
 	if err != nil {
 		return err


### PR DESCRIPTION
It is not a bug as Go ignore additional conn.close() but they are called twice. The connection will be closed in https://github.com/SagerNet/sing-box/blob/fd705d965e0dfdc7252a5d4df40bebb8890c32af/experimental/libbox/command_server.go#L142