### PR TITLE
Fix some error in docs

### DIFF
--- a/docs/configuration/dns/rule.zh.md
+++ b/docs/configuration/dns/rule.zh.md
@@ -355,19 +355,19 @@ DNS 查询类型。值可以为整数或者类型名称字符串。
 
 #### geoip
 
-!!! question "自 sing-box 1.8.0 起"
+!!! question "自 sing-box 1.9.0 起"
 
 与查询响应匹配 GeoIP。
 
 #### ip_cidr
 
-!!! question "自 sing-box 1.8.0 起"
+!!! question "自 sing-box 1.9.0 起"
 
 与查询相应匹配 IP CIDR。
 
 #### ip_is_private
 
-!!! question "自 sing-box 1.8.0 起"
+!!! question "自 sing-box 1.9.0 起"
 
 与查询响应匹配非公开 IP。
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,7 +133,6 @@ nav:
           - WireGuard: configuration/outbound/wireguard.md
           - Hysteria: configuration/outbound/hysteria.md
           - ShadowTLS: configuration/outbound/shadowtls.md
-          - ShadowsocksR: configuration/outbound/shadowsocksr.md
           - VLESS: configuration/outbound/vless.md
           - TUIC: configuration/outbound/tuic.md
           - Hysteria2: configuration/outbound/hysteria2.md


### PR DESCRIPTION
- ShadowsocksR outbound protocol has been removed, but it still has an entry in nav sidebar which redirects to 404 error page
- Address Filter Fields in DNS rule was added in sing-box 1.9.0 but zh docs states it's 1.8.0