### PR TITLE
fixed dns exchange index

### DIFF
--- a/route/router_dns.go
+++ b/route/router_dns.go
@@ -47,7 +47,7 @@ func (r *Router) matchDNS(ctx context.Context, allowFakeIP bool, index int) (con
 		if index != -1 {
 			dnsRules = dnsRules[index+1:]
 		}
-		for ruleIndex, rule := range dnsRules {
+		for currentRuleIndex, rule := range dnsRules {
 			metadata.ResetRuleCache()
 			if rule.Match(metadata) {
 				detour := rule.Outbound()
@@ -60,11 +60,11 @@ func (r *Router) matchDNS(ctx context.Context, allowFakeIP bool, index int) (con
 				if isFakeIP && !allowFakeIP {
 					continue
 				}
-				displayRuleIndex := ruleIndex
+				ruleIndex := currentRuleIndex
 				if index != -1 {
-					displayRuleIndex += index + 1
+					ruleIndex += index + 1
 				}
-				r.dnsLogger.DebugContext(ctx, "match[", displayRuleIndex, "] ", rule.String(), " => ", detour)
+				r.dnsLogger.DebugContext(ctx, "match[", ruleIndex, "] ", rule.String(), " => ", detour)
 				if (isFakeIP && !r.dnsIndependentCache) || rule.DisableCache() {
 					ctx = dns.ContextWithDisableCache(ctx, true)
 				}
@@ -75,9 +75,9 @@ func (r *Router) matchDNS(ctx context.Context, allowFakeIP bool, index int) (con
 					ctx = dns.ContextWithClientSubnet(ctx, *clientSubnet)
 				}
 				if domainStrategy, dsLoaded := r.transportDomainStrategy[transport]; dsLoaded {
-					return ctx, transport, domainStrategy, rule, displayRuleIndex
+					return ctx, transport, domainStrategy, rule, ruleIndex
 				} else {
-					return ctx, transport, r.defaultDomainStrategy, rule, displayRuleIndex
+					return ctx, transport, r.defaultDomainStrategy, rule, ruleIndex
 				}
 			}
 		}

--- a/route/router_dns.go
+++ b/route/router_dns.go
@@ -75,9 +75,9 @@ func (r *Router) matchDNS(ctx context.Context, allowFakeIP bool, index int) (con
 					ctx = dns.ContextWithClientSubnet(ctx, *clientSubnet)
 				}
 				if domainStrategy, dsLoaded := r.transportDomainStrategy[transport]; dsLoaded {
-					return ctx, transport, domainStrategy, rule, ruleIndex
+					return ctx, transport, domainStrategy, rule, displayRuleIndex
 				} else {
-					return ctx, transport, r.defaultDomainStrategy, rule, ruleIndex
+					return ctx, transport, r.defaultDomainStrategy, rule, displayRuleIndex
 				}
 			}
 		}


### PR DESCRIPTION
Fixed the ruleIndex returned by the DNS match. 

The returned ruleIndex is the fragmented rules index. It is normal after the first matching failure, but an error will occur later.

The error arises when the "addressLimit && rejected" result is encountered multiple times during the DNS exchange.