### PR TITLE
Fix the installation location of service files in prebuilded package

### DIFF
--- a/.goreleaser.fury.yaml
+++ b/.goreleaser.fury.yaml
@@ -50,9 +50,9 @@ nfpms:
         dst: /etc/sing-box/config.json
         type: config
       - src: release/config/sing-box.service
-        dst: /etc/systemd/system/sing-box.service
+        dst: /usr/lib/systemd/system/sing-box.service
       - src: release/config/sing-box@.service
-        dst: /etc/systemd/system/sing-box@.service
+        dst: /usr/lib/systemd/system/sing-box@.service
       - src: LICENSE
         dst: /usr/share/licenses/sing-box/LICENSE
     conflicts:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -128,9 +128,9 @@ nfpms:
         dst: /etc/sing-box/config.json
         type: config
       - src: release/config/sing-box.service
-        dst: /etc/systemd/system/sing-box.service
+        dst: /usr/lib/systemd/system/sing-box.service
       - src: release/config/sing-box@.service
-        dst: /etc/systemd/system/sing-box@.service
+        dst: /usr/lib/systemd/system/sing-box@.service
       - src: LICENSE
         dst: /usr/share/licenses/sing-box/LICENSE
     deb:


### PR DESCRIPTION
According to the specification ([Man page](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Unit%20File%20Load%20Path)), the packaged service file should be installed in `/usr/lib/systemd/system`, not `/etc/systemd/system`.

| Path | Description |
|-|-|
| /etc/systemd/system | System units created by the administrator |
| /usr/lib/systemd/system | System units installed by the distribution package manager |