### PR TITLE
sniff_override_destination 应该在创建链接前覆盖

### DIFF
--- a/route/router.go
+++ b/route/router.go
@@ -785,12 +785,6 @@ func (r *Router) RouteConnection(ctx context.Context, conn net.Conn, metadata ad
 		if sniffMetadata != nil {
 			metadata.Protocol = sniffMetadata.Protocol
 			metadata.Domain = sniffMetadata.Domain
-			if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
-				metadata.Destination = M.Socksaddr{
-					Fqdn: metadata.Domain,
-					Port: metadata.Destination.Port,
-				}
-			}
 			if metadata.Domain != "" {
 				r.logger.DebugContext(ctx, "sniffed protocol: ", metadata.Protocol, ", domain: ", metadata.Domain)
 			} else {
@@ -833,6 +827,12 @@ func (r *Router) RouteConnection(ctx context.Context, conn net.Conn, metadata ad
 	}
 	if !common.Contains(detour.Network(), N.NetworkTCP) {
 		return E.New("missing supported outbound, closing connection")
+	}
+	if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
+		metadata.Destination = M.Socksaddr{
+			Fqdn: metadata.Domain,
+			Port: metadata.Destination.Port,
+		}
 	}
 	if r.clashServer != nil {
 		trackerConn, tracker := r.clashServer.RoutedConnection(ctx, conn, metadata, matchedRule)
@@ -912,12 +912,6 @@ func (r *Router) RoutePacketConnection(ctx context.Context, conn N.PacketConn, m
 			if sniffMetadata != nil {
 				metadata.Protocol = sniffMetadata.Protocol
 				metadata.Domain = sniffMetadata.Domain
-				if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
-					metadata.Destination = M.Socksaddr{
-						Fqdn: metadata.Domain,
-						Port: metadata.Destination.Port,
-					}
-				}
 				if metadata.Domain != "" {
 					r.logger.DebugContext(ctx, "sniffed packet protocol: ", metadata.Protocol, ", domain: ", metadata.Domain)
 				} else {
@@ -953,6 +947,12 @@ func (r *Router) RoutePacketConnection(ctx context.Context, conn N.PacketConn, m
 	}
 	if !common.Contains(detour.Network(), N.NetworkUDP) {
 		return E.New("missing supported outbound, closing packet connection")
+	}
+	if metadata.InboundOptions.SniffOverrideDestination && M.IsDomainName(metadata.Domain) {
+		metadata.Destination = M.Socksaddr{
+			Fqdn: metadata.Domain,
+			Port: metadata.Destination.Port,
+		}
 	}
 	if r.clashServer != nil {
 		trackerConn, tracker := r.clashServer.RoutedPacketConnection(ctx, conn, metadata, matchedRule)


### PR DESCRIPTION
探测出域名后，立即覆盖目标地址，会导致 `ip` 匹配规则失效。

如果使用 `inbounds.domain_strategy` 则变成了，用户传入 `ip` 探测出域名后，又去重新解析为 `ip` ，而出站链接也变成了 `ip`。

`sniff_override_destination ` 应保证最后的出站链接为域名