### PR TITLE
[feat] add an API to get the final url after following redirect responses

### DIFF
--- a/experimental/libbox/http.go
+++ b/experimental/libbox/http.go
@@ -52,6 +52,7 @@ type HTTPRequest interface {
 type HTTPResponse interface {
 	GetContent() ([]byte, error)
 	GetContentString() (string, error)
+	GetFinalURL() string
 	WriteTo(path string) error
 }
 
@@ -231,6 +232,11 @@ func (h *httpResponse) GetContentString() (string, error) {
 		return "", err
 	}
 	return string(content), nil
+}
+
+func (h *httpResponse) GetFinalURL() string {
+	finalURL := h.Request.URL.String()
+	return finalURL
 }
 
 func (h *httpResponse) WriteTo(path string) error {


### PR DESCRIPTION
### Description
This change adds a new Method `getFinalURL() -> string` to `experimental/libbox.HTTPResponse`, which allows the caller obtain the final URL after been redirected.


### Motivation
This change should bring the following benefits:

- performance improvement
- enhance robustness
- server can have more flexible update strategies
- reduce reconfiguration work for user


### Expected influences
None
According to [Ref1](https://pkg.go.dev/net/http#Client), `net/http.Client` will follows a redirect response (if less than 10 times) by default. From my test, all existing sing-box apps follow this default behaviour, and this change will not break this behaviour. In addition, the connection can be protected by TLS, so this change should not introduce extra security issue.