### PR TITLE
fix fake IP mapping after fake IP pool runs out

### DIFF
--- a/route/router_dns.go
+++ b/route/router_dns.go
@@ -65,7 +65,7 @@ func (r *Router) matchDNS(ctx context.Context, allowFakeIP bool, index int) (con
 					ruleIndex += index + 1
 				}
 				r.dnsLogger.DebugContext(ctx, "match[", ruleIndex, "] ", rule.String(), " => ", detour)
-				if (isFakeIP && !r.dnsIndependentCache) || rule.DisableCache() {
+				if isFakeIP || rule.DisableCache() {
 					ctx = dns.ContextWithDisableCache(ctx, true)
 				}
 				if rewriteTTL := rule.RewriteTTL(); rewriteTTL != nil {

--- a/transport/fakeip/memory.go
+++ b/transport/fakeip/memory.go
@@ -40,6 +40,13 @@ func (s *MemoryStorage) FakeIPSaveMetadataAsync(metadata *adapter.FakeIPMetadata
 func (s *MemoryStorage) FakeIPStore(address netip.Addr, domain string) error {
 	s.addressAccess.Lock()
 	s.domainAccess.Lock()
+	if oldDomain, loaded := s.addressCache[address]; loaded {
+		if address.Is4() {
+			delete(s.domainCache4, oldDomain)
+		} else {
+			delete(s.domainCache6, oldDomain)
+		}
+	}
 	s.addressCache[address] = domain
 	if address.Is4() {
 		s.domainCache4[domain] = address


### PR DESCRIPTION
#1713
- Delete old existing mapping record
- Disable cache for fake IP servers to prevent old mapping records being cached
- To avoid deleting old but active mapping records, LRU may be needed