### PR TITLE
Remove vendor in RPM packages

### DIFF
--- a/.goreleaser.fury.yaml
+++ b/.goreleaser.fury.yaml
@@ -36,7 +36,6 @@ nfpms:
     file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     builds:
       - main
-    vendor: sagernet
     homepage: https://sing-box.sagernet.org/
     maintainer: nekohasekai <contact-git@sekai.icu>
     description: The universal proxy platform.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -113,7 +113,6 @@ nfpms:
     file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     builds:
       - main
-    vendor: sagernet
     homepage: https://sing-box.sagernet.org/
     maintainer: nekohasekai <contact-git@sekai.icu>
     description: The universal proxy platform.


### PR DESCRIPTION
Gemfury won't sync the vendor from RPM packages to RPM-MD repositories, resulting information mismatch.