### PR TITLE
Add KernelSU root permission detection for auto-redirect

### DIFF
--- a/inbound/tun_auto_redirect.go
+++ b/inbound/tun_auto_redirect.go
@@ -61,26 +61,20 @@ func newAutoRedirect(t *Tun) (*tunAutoRedirect, error) {
 				suPath string
 				err    error
 			)
-			if t.platformInterface != nil {
-				suPaths := []string{
-					"/bin/su",
-					"/system/bin/su",
+			for _, suPath = range []string{
+				"su",
+				"/system/bin/su",
+			} {
+				suPath, err = exec.LookPath(suPath)
+				if err == nil {
+					break
 				}
-				for _, path := range suPaths {
-					suPath, err = exec.LookPath(path)
-					if err == nil {
-						break
-					}
-				}
-			} else {
-				suPath, err = exec.LookPath("su")
 			}
-			if err == nil {
-				s.androidSu = true
-				s.suPath = suPath
-			} else {
+			if err != nil {
 				return nil, E.Extend(E.Cause(err, "root permission is required for auto redirect"), os.Getenv("PATH"))
 			}
+			s.androidSu = true
+			s.suPath = suPath
 		}
 	} else {
 		err := s.initializeNfTables()

--- a/inbound/tun_auto_redirect.go
+++ b/inbound/tun_auto_redirect.go
@@ -62,7 +62,16 @@ func newAutoRedirect(t *Tun) (*tunAutoRedirect, error) {
 				err    error
 			)
 			if t.platformInterface != nil {
-				suPath, err = exec.LookPath("/bin/su")
+				suPaths := []string{
+					"/bin/su",
+					"/system/bin/su",
+				}
+				for _, path := range suPaths {
+					suPath, err = exec.LookPath(path)
+					if err == nil {
+						break
+					}
+				}
 			} else {
 				suPath, err = exec.LookPath("su")
 			}


### PR DESCRIPTION
Referring to [KernelSU Code](https://github.com/tiann/KernelSU/blob/b766b98513b5a7eb33bc1c4a76b5702bf1288f07/userspace/ksud/src/cli.rs#L286), KernelSU can only get root permission via `/system/bin/su` or `su`.

This patch should also work for other root solutions like Magisk and Apatch.