### PR TITLE
Support for host in HTTPupgrade header

### DIFF
--- a/transport/v2rayhttpupgrade/client.go
+++ b/transport/v2rayhttpupgrade/client.go
@@ -60,8 +60,13 @@ func NewClient(ctx context.Context, dialer N.Dialer, serverAddr M.Socksaddr, opt
 		requestURL.Path = "/" + requestURL.Path
 	}
 	headers := make(http.Header)
-	for key, value := range options.Headers {
-		headers[key] = value
+	for key, values := range options.Headers {
+		for _, value := range values {
+			headers.Add(key, value)
+		}
+	}
+	if headersHost := headers.Get("host"); headersHost != "" {
+		host = headersHost
 	}
 	return &Client{
 		dialer:     dialer,


### PR DESCRIPTION
This PR introduces support for the “Host” header in HTTP upgrade requests, addressing issue #1841 without disrupting the existing codebase and logic of Sing-Box.

In striving for minimal changes, I encountered a case sensitivity issue:

```Go
if headersHost := headers.Get("host"); headersHost != "" {
	host = headersHost
}
```

The code functioned correctly when the key was “Host” but failed to recognize “host”: Example:

```JSON
"headers": {
	"Host": "domain.com"
}
```
This works, whereas:
```JSON
"headers": {
	"host": "domain.com"
}
```
does not.

To resolve this, I modified a few lines to ensure case-insensitive handling.

I’m open to any feedback. XD

Special thanks to @mmmray for invaluable tips and assistance.

P.S.: I believe this enhancement promotes consistency across transports and simplifies the parser development for Sing-Box.