### PR TITLE
urltest: force refresh history while starting it

### DIFF
--- a/experimental/clashapi/server_resources.go
+++ b/experimental/clashapi/server_resources.go
@@ -78,8 +78,10 @@ func (s *Server) downloadExternalUI() error {
 	err = s.downloadZIP(filepath.Base(downloadURL), response.Body, s.externalUI)
 	if err != nil {
 		removeAllInDirectory(s.externalUI)
+		return err
 	}
-	return err
+	s.logger.Info("download external ui successfully")
+	return nil
 }
 
 func (s *Server) downloadZIP(name string, body io.Reader, output string) error {

--- a/outbound/urltest.go
+++ b/outbound/urltest.go
@@ -88,12 +88,7 @@ func (s *URLTest) Start() error {
 		return err
 	}
 	s.group = group
-	return nil
-}
-
-func (s *URLTest) PostStart() error {
-	s.group.PostStart()
-	return nil
+	return s.group.Start()
 }
 
 func (s *URLTest) Close() error {
@@ -253,10 +248,15 @@ func NewURLTestGroup(
 	}, nil
 }
 
-func (g *URLTestGroup) PostStart() {
+func (g *URLTestGroup) Start() error {
+	_, err := g.urlTest(g.ctx, true)
+	if err != nil {
+		return E.New("failed to start urltest group: ", err)
+	}
 	g.started = true
 	g.lastActive.Store(time.Now())
 	go g.CheckOutbounds(false)
+	return nil
 }
 
 func (g *URLTestGroup) Touch() {


### PR DESCRIPTION
While downloading external resources in the server start phase, if the first outbound is unavailable, the `urltest` fallback to the `selector` with the first outbound as default. We might health check the outbound first while initializing the `urltest` group.