### PR TITLE
optimize: reduce func findProcessName mem allocs and copy

### DIFF
--- a/common/process/searcher_darwin.go
+++ b/common/process/searcher_darwin.go
@@ -60,12 +60,12 @@ func findProcessName(network string, ip netip.Addr, port int) (string, error) {
 
 	isIPv4 := ip.Is4()
 
-	value, err := syscall.Sysctl(spath)
+	value, err := unix.SysctlRaw(spath)
 	if err != nil {
 		return "", err
 	}
 
-	buf := []byte(value)
+	buf := value
 
 	// from darwin-xnu/bsd/netinet/in_pcblist.c:get_pcblist_n
 	// size/offset are round up (aligned) to 8 bytes in darwin


### PR DESCRIPTION
`syscall.Sysctl` make a slice byte buf and convert to string when return. 
`func findProcessName` convert string to slice byte again. 
This malloc and copy mem twice unnecessarily.
`net.inet.tcp.pcblist_n` usually not a small piece of mem, and copy twice would cause mem waste.
Use `golang.org/x/sys/unix.SysctlRaw` instead.