### PR TITLE
Fix cache/v2ray/clashapi not call post start issue

### DIFF
--- a/box.go
+++ b/box.go
@@ -371,6 +371,12 @@ func (s *Box) start() error {
 			return err
 		}
 	}
+	for _, lifecycleService := range s.services {
+		err = lifecycleService.Start(adapter.StartStateStarted)
+		if err != nil {
+			return E.Cause(err, "start state started", lifecycleService.Name())
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
I found V1.11.0-alpha.11 not start call cache/v2ray/clash api service StartStateStarted stage, i fix by call StartStateStarted at end of box.go start method.