### PR TITLE
hysteria2: fix support both string and json in masquerade

### DIFF
--- a/option/hysteria2.go
+++ b/option/hysteria2.go
@@ -74,6 +74,7 @@ func (m *Hysteria2Masquerade) UnmarshalJSON(bytes []byte) error {
 		default:
 			return E.New("unknown masquerade URL scheme: ", masqueradeURL.Scheme)
 		}
+		return nil
 	}
 	err = json.Unmarshal(bytes, (*_Hysteria2Masquerade)(m))
 	if err != nil {


### PR DESCRIPTION
Currently, using string for Hysteria2 masquerade option will cause error.
Reason: After parsing string, unmarshal object will start as well.