### PR TITLE
Fix Outbound deadlock

### DIFF
--- a/adapter/outbound/manager.go
+++ b/adapter/outbound/manager.go
@@ -246,8 +246,6 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 	if err != nil {
 		return err
 	}
-	m.access.Lock()
-	defer m.access.Unlock()
 	if m.started {
 		for _, stage := range adapter.ListStartStages {
 			err = adapter.LegacyStart(outbound, stage)
@@ -256,6 +254,8 @@ func (m *Manager) Create(ctx context.Context, router adapter.Router, logger log.
 			}
 		}
 	}
+	m.access.Lock()
+	defer m.access.Unlock()
 	if existsOutbound, loaded := m.outboundByTag[tag]; loaded {
 		if m.started {
 			err = common.Close(existsOutbound)


### PR DESCRIPTION
On outbound `Create` function, when `Manager` is started, it calls `LegacyStart`.

Only remained `LegacyStart` for outbound may have sth to do for `urltest`, `selector` and `tor`.
On `urltest` and `selector`, function `Start()` will be called and it checks all detour outbounds. In this call, lock will cause deadlock.

Simple process schema when manager is started:
```code
manager.Create(<selector|urltest>) [LOCK]
-> LegacyStart
-> outbound.Start()
-> manager.Outbound(<tag>) [LOCK] --> DEADLOCK
```

As far as we have no other usage for `LegacyStart` and it does not need access lock, it is better to lock manager access after running `LegacyStart` on --**STARTED**-- manager.