### PR TITLE
Fix missing AnyTLS display name

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -78,6 +78,8 @@ func ProxyDisplayName(proxyType string) string {
 		return "TUIC"
 	case TypeHysteria2:
 		return "Hysteria2"
+	case TypeAnyTLS:
+		return "AnyTLS"
 	case TypeSelector:
 		return "Selector"
 	case TypeURLTest:


### PR DESCRIPTION
Fix missing display name for AnyTLS in clash API