### PR TITLE
Fix grpclite memory leak issue, close reader's underlying io.Reader.

### DIFF
--- a/transport/v2raygrpclite/conn.go
+++ b/transport/v2raygrpclite/conn.go
@@ -21,7 +21,7 @@ import (
 var _ net.Conn = (*GunConn)(nil)
 
 type GunConn struct {
-	rd            io.Reader
+	rawReader     io.Reader
 	reader        *std_bufio.Reader
 	writer        io.Writer
 	flusher       http.Flusher
@@ -32,10 +32,10 @@ type GunConn struct {
 
 func newGunConn(reader io.Reader, writer io.Writer, flusher http.Flusher) *GunConn {
 	return &GunConn{
-		rd:      reader,
-		reader:  std_bufio.NewReader(reader),
-		writer:  writer,
-		flusher: flusher,
+		rawReader: reader,
+		reader:    std_bufio.NewReader(reader),
+		writer:    writer,
+		flusher:   flusher,
 	}
 }
 
@@ -48,7 +48,7 @@ func newLateGunConn(writer io.Writer) *GunConn {
 
 func (c *GunConn) setup(reader io.Reader, err error) {
 	if reader != nil {
-		c.rd = reader
+		c.rawReader = reader
 		c.reader = std_bufio.NewReader(reader)
 	}
 	c.err = err
@@ -141,7 +141,7 @@ func (c *GunConn) FrontHeadroom() int {
 }
 
 func (c *GunConn) Close() error {
-	return common.Close(c.rd, c.writer)
+	return common.Close(c.rawReader, c.writer)
 }
 
 func (c *GunConn) LocalAddr() net.Addr {

--- a/transport/v2raygrpclite/conn.go
+++ b/transport/v2raygrpclite/conn.go
@@ -21,6 +21,7 @@ import (
 var _ net.Conn = (*GunConn)(nil)
 
 type GunConn struct {
+	rd            io.Reader
 	reader        *std_bufio.Reader
 	writer        io.Writer
 	flusher       http.Flusher
@@ -31,6 +32,7 @@ type GunConn struct {
 
 func newGunConn(reader io.Reader, writer io.Writer, flusher http.Flusher) *GunConn {
 	return &GunConn{
+		rd:      reader,
 		reader:  std_bufio.NewReader(reader),
 		writer:  writer,
 		flusher: flusher,
@@ -46,6 +48,7 @@ func newLateGunConn(writer io.Writer) *GunConn {
 
 func (c *GunConn) setup(reader io.Reader, err error) {
 	if reader != nil {
+		c.rd = reader
 		c.reader = std_bufio.NewReader(reader)
 	}
 	c.err = err
@@ -138,7 +141,7 @@ func (c *GunConn) FrontHeadroom() int {
 }
 
 func (c *GunConn) Close() error {
-	return common.Close(c.reader, c.writer)
+	return common.Close(c.rd, c.writer)
 }
 
 func (c *GunConn) LocalAddr() net.Addr {


### PR DESCRIPTION
There's serveral issue related:
#702  #1170 

When i use an outbound with grpc transport, after run Speedtest app or https://speedtest.net, memory grows very fast (usually >100MB on my Macbook). It's caused by http.response.Body is not closed when exec conn.Close(), the conn.Reader's type if bufio.Reader, common.Close will not close underlying rd.

This pr shows a way to solve the issue.