### PR TITLE
Fix hosts dns resolver

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -537,7 +537,7 @@ func FixedResponse(id uint16, question dns.Question, addresses []netip.Addr, tim
 		Question: []dns.Question{question},
 	}
 	for _, address := range addresses {
-		if address.Is4() {
+		if address.Is4() && question.Qtype == dns.TypeA {
 			response.Answer = append(response.Answer, &dns.A{
 				Hdr: dns.RR_Header{
 					Name:   question.Name,
@@ -547,7 +547,7 @@ func FixedResponse(id uint16, question dns.Question, addresses []netip.Addr, tim
 				},
 				A: address.AsSlice(),
 			})
-		} else {
+		} else if address.Is6() && question.Qtype == dns.TypeAAAA {
 			response.Answer = append(response.Answer, &dns.AAAA{
 				Hdr: dns.RR_Header{
 					Name:   question.Name,

--- a/dns/transport/hosts/hosts_file.go
+++ b/dns/transport/hosts/hosts_file.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/miekg/dns"
 )
 
 const cacheMaxAge = 5 * time.Second
@@ -91,8 +89,9 @@ func (f *File) update() {
 			continue
 		}
 		for index := 1; index < len(fields); index++ {
-			canonicalName := dns.CanonicalName(fields[index])
-			byName[canonicalName] = append(byName[canonicalName], addr)
+			// canonicalName := dns.CanonicalName(fields[index])
+			domain := fields[index]
+			byName[domain] = append(byName[domain], addr)
 		}
 	}
 	f.expire = now.Add(cacheMaxAge)

--- a/dns/transport/hosts/hosts_file.go
+++ b/dns/transport/hosts/hosts_file.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/miekg/dns"
 )
 
 const cacheMaxAge = 5 * time.Second
@@ -32,7 +34,7 @@ func (f *File) Lookup(name string) []netip.Addr {
 	f.access.Lock()
 	defer f.access.Unlock()
 	f.update()
-	return f.byName[name]
+	return f.byName[dns.CanonicalName(name)]
 }
 
 func (f *File) update() {
@@ -89,9 +91,8 @@ func (f *File) update() {
 			continue
 		}
 		for index := 1; index < len(fields); index++ {
-			// canonicalName := dns.CanonicalName(fields[index])
-			domain := fields[index]
-			byName[domain] = append(byName[domain], addr)
+			canonicalName := dns.CanonicalName(fields[index])
+			byName[canonicalName] = append(byName[canonicalName], addr)
 		}
 	}
 	f.expire = now.Add(cacheMaxAge)

--- a/dns/transport/hosts/hosts_test.go
+++ b/dns/transport/hosts/hosts_test.go
@@ -11,6 +11,6 @@ import (
 
 func TestHosts(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, []netip.Addr{netip.AddrFrom4([4]byte{127, 0, 0, 1}), netip.IPv6Loopback()}, hosts.NewFile("testdata/hosts").Lookup("localhost."))
-	require.NotEmpty(t, hosts.NewFile(hosts.DefaultPath).Lookup("localhost."))
+	require.Equal(t, []netip.Addr{netip.AddrFrom4([4]byte{127, 0, 0, 1}), netip.IPv6Loopback()}, hosts.NewFile("testdata/hosts").Lookup("localhost"))
+	require.NotEmpty(t, hosts.NewFile(hosts.DefaultPath).Lookup("localhost"))
 }

--- a/option/dns.go
+++ b/option/dns.go
@@ -316,8 +316,8 @@ type LegacyDNSServerOptions struct {
 }
 
 type HostsDNSServerOptions struct {
-	Path       badoption.Listable[string]                               `json:"path,omitempty"`
-	Predefined badjson.TypedMap[string, badoption.Listable[netip.Addr]] `json:"predefined,omitempty"`
+	Path       badoption.Listable[string]                                `json:"path,omitempty"`
+	Predefined *badjson.TypedMap[string, badoption.Listable[netip.Addr]] `json:"predefined,omitempty"`
 }
 
 type LocalDNSServerOptions struct {


### PR DESCRIPTION
hosts无法按预期返回的bug

Root cases
* Predefined逻辑未实现
* Hosts File解析时使用canonical name，然而传入的是domain

Solutions
* 实现了Predefined逻辑
* Hosts File解析时使用domain查找