### PR TITLE
Add dialer options for remote ruleset

### DIFF
--- a/docs/configuration/route/index.md
+++ b/docs/configuration/route/index.md
@@ -114,6 +114,7 @@ Takes no effect if `outbound.routing_mark` is set.
 See [Dial Fields](/configuration/shared/dial/#domain_resolver) for details.
 
 Can be overrides by `outbound.domain_resolver`.
+Can be overrides by `ruleset.domain_resolver`.
 
 #### default_network_strategy
 

--- a/docs/configuration/route/index.zh.md
+++ b/docs/configuration/route/index.zh.md
@@ -113,6 +113,7 @@ icon: material/alert-decagram
 详情参阅 [拨号字段](/configuration/shared/dial/#domain_resolver)。
 
 可以被 `outbound.domain_resolver` 覆盖。
+可以被 `ruleset.domain_resolver` 覆盖。
 
 #### network_strategy
 

--- a/docs/configuration/rule-set/index.md
+++ b/docs/configuration/rule-set/index.md
@@ -43,8 +43,12 @@
       "tag": "",
       "format": "source", // or binary
       "url": "",
+      "update_interval": "", // optional
       "download_detour": "", // optional
-      "update_interval": "" // optional
+      "detour": "", // optional
+      "domain_resolver": "" // optional
+
+      ... // Dial Fields
     }
     ```
 
@@ -100,14 +104,28 @@ File path of rule-set.
 
 Download URL of rule-set.
 
-#### download_detour
-
-Tag of the outbound to download rule-set.
-
-Default outbound will be used if empty.
-
 #### update_interval
 
 Update interval of rule-set.
 
 `1d` will be used if empty.
+
+### download_detour
+This field is retained for compatibility only, please use the detour field.
+When both this field and the detour field have valid content, the content of the detour field takes precedence.
+
+#### detour
+
+Tag of the outbound to download rule-set.
+
+Default outbound will be used if empty.
+
+#### domain_resolver
+
+Set domain resolver to use for resolving domain names.
+
+If this option and router.default_domain_resolver are set at the same time, router.default_domain_resolver will be overwritten
+
+### Dial Fields
+
+See [Dial Fields](/configuration/shared/dial/) for details.

--- a/docs/configuration/rule-set/index.zh.md
+++ b/docs/configuration/rule-set/index.zh.md
@@ -43,8 +43,12 @@
       "tag": "",
       "format": "source", // or binary
       "url": "",
+      "update_interval": "", // 可选
       "download_detour": "", // 可选
-      "update_interval": "" // 可选
+      "detour": "", // 可选
+      "domain_resolver": "" // 可选
+
+      ... // 拨号字段
     }
     ```
 
@@ -100,14 +104,28 @@
 
 规则集的下载 URL。
 
-#### download_detour
-
-用于下载规则集的出站的标签。
-
-如果为空，将使用默认出站。
-
 #### update_interval
 
 规则集的更新间隔。
 
 默认使用 `1d`。
+
+### download_detour
+保留此字段只是为了保证兼容性，请使用detour字段
+在此字段和detour字段的内容都有效时，优先使用detour字段的内容
+
+#### detour
+
+用于下载规则集的出站的标签。
+
+如果为空，将使用默认出站。
+
+#### domain_resolver
+
+用于设置解析域名的域名解析器。
+
+如果此选项和router.default_domain_resolver同时设置，router.default_domain_resolver会被覆盖
+
+### 拨号字段
+
+参阅 [拨号字段](/zh/configuration/shared/dial/)。

--- a/option/rule_set.go
+++ b/option/rule_set.go
@@ -85,9 +85,11 @@ type LocalRuleSet struct {
 }
 
 type RemoteRuleSet struct {
+	DialerOptions
 	URL            string             `json:"url"`
-	DownloadDetour string             `json:"download_detour,omitempty"`
 	UpdateInterval badoption.Duration `json:"update_interval,omitempty"`
+	// keep this filed for compatibility, use Detour field please
+	DownloadDetour string `json:"download_detour,omitempty"`
 }
 
 type _HeadlessRule struct {


### PR DESCRIPTION
Remote Ruleset新增Dialer支持，允许Remote Ruleset像outbound一样覆盖default_domain_resolver的设置

### 起因：
一般情况下default_domain_resolver可以满足ruleset的解析，但是当使用一些内部私有地址时，在公共服务器上无法正确解析
下面是个例子，此时private-ruleset无法正确下载，因为`https://example.com`并不能被dns_ali正确解析
```json
{
  "dns": {
    "servers": [ "dns_ali" ]
  },
  "route": {
    "default_domain_resolver": {
      "server": "dns_ali"
    },
    ...
    "rule_set": [
      {
        "tag": "private-ruleset",
        "type": "remote",
        "format": "source",
        "url": "https://example.com/something.json",
        "download_detour": "DIRECT-OUT"
      }
    ]
  }
```

### 解决方案：
给Remote Ruleset添加dialer支持，在进行下载Ruleset文件时，如果设置了domain_resolver将覆盖default_domain_resolver，以用户设置进行解析。行为上与outbound一致。
下面是个例子，此时private-ruleset将使用dns_private进行解析，而public-ruleset则继续走原有规则使用dns_ali进行解析
```json
{
  "dns": {
    "servers": [
      "dns_ali",
      "dns_private"
    ]
  },
  "route": {
    "default_domain_resolver": {
      "server": "dns_ali"
    },
    ...
    "rule_set": [
      {
        "tag": "private-ruleset",
        "type": "remote",
        "format": "source",
        "url": "https://example.com/something.json",
        "detour": "PRIVATE-OUT",
        "domain_resolver": "dns_private"
      },
      {
        "tag": "public-ruleset",
        "type": "remote",
        "format": "source",
        "url": "A valid public URL",
      }
    ]
  }
```

### 受影响的现有逻辑：
保留了download_detour字段，在detour字段为空，download_detour字段内容都有效时，使用download_detour的值
在detour字段和download_detour字段内容都有效时，优先使用detour的值
