### PR TITLE
Allow libbox to accept a separate context

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,15 +2,96 @@
 icon: material/alert-decagram
 ---
 
+#### 1.12.0-alpha.17
+
+* Add NTP sniffer **1**
+* Fixes and improvements
+
+**1**:
+
+See [Protocol Sniff](/configuration/route/sniff/).
+
+#### 1.12.0-alpha.16
+
+* Update `domain_resolver` behavior **1**
+* Fixes and improvements
+
+**1**:
+
+`route.default_domain_resolver` or `outbound.domain_resolver` is now optional when only one DNS server is configured.
+
+See [Dial Fields](/configuration/shared/dial/#domain_resolver).
+
 ### 1.11.5
 
 * Fixes and improvements
 
 _We are temporarily unable to update sing-box apps on the App Store because the reviewer mistakenly found that we violated the rules (TestFlight users are not affected)._
 
+#### 1.12.0-alpha.13
+
+* Move `predefined` DNS server to DNS rule action **1**
+* Fixes and improvements
+
+**1**:
+
+See [DNS Rule Action](/configuration/dns/rule_action/#predefined).
+
 ### 1.11.4
 
 * Fixes and improvements
+
+#### 1.12.0-alpha.11
+
+* Fixes and improvements
+
+#### 1.12.0-alpha.10
+
+* Add AnyTLS protocol **1**
+* Improve `resolve` route action **2**
+* Migrate to stdlib ECH implementation **3**
+* Fixes and improvements
+
+**1**:
+
+The new AnyTLS protocol claims to mitigate TLS proxy traffic characteristics and comes with a new multiplexing scheme.
+
+See [AnyTLS Inbound](/configuration/inbound/anytls/) and [AnyTLS Outbound](/configuration/outbound/anytls/).
+
+**2**:
+
+`resolve` route action now accepts `disable_cache` and other options like in DNS route actions, see [Route Action](/configuration/route/rule_action).
+
+**3**:
+
+See [TLS](/configuration/shared/tls).
+
+The build tag `with_ech` is no longer needed and has been removed.
+
+#### 1.12.0-alpha.7
+
+* Add Tailscale DNS server **1**
+* Fixes and improvements
+
+**1**:
+
+See [Tailscale](/configuration/dns/server/tailscale/).
+
+#### 1.12.0-alpha.6
+
+* Add Tailscale endpoint **1**
+* Drop support for go1.22 **2**
+* Fixes and improvements
+
+**1**:
+
+See [Tailscale](/configuration/endpoint/tailscale/).
+
+**2**:
+
+Due to maintenance difficulties, sing-box 1.12.0 requires at least Go 1.23 to compile.
+
+For Windows 7 users, legacy binaries now continue to compile with Go 1.23 and patches from [MetaCubeX/go](https://github.com/MetaCubeX/go).
 
 ### 1.11.3
 
@@ -18,9 +99,68 @@ _We are temporarily unable to update sing-box apps on the App Store because the 
 
 _This version overwrites 1.11.2, as incorrect binaries were released due to a bug in the continuous integration process._
 
+#### 1.12.0-alpha.5
+
+* Fixes and improvements
+
 ### 1.11.1
 
 * Fixes and improvements
+
+#### 1.12.0-alpha.2
+
+* Update quic-go to v0.49.0
+* Fixes and improvements
+
+#### 1.12.0-alpha.1
+
+* Refactor DNS servers **1**
+* Add domain resolver options**2**
+* Add TLS fragment route options **3**
+* Add certificate options **4**
+
+**1**:
+
+DNS servers are refactored for better performance and scalability.
+
+See [DNS server](/configuration/dns/server/).
+
+For migration, see [Migrate to new DNS server formats](/migration/#migrate-to-new-dns-servers).
+
+Compatibility for old formats will be removed in sing-box 1.14.0.
+
+**2**:
+
+Legacy `outbound` DNS rules are deprecated
+and can be replaced by the new `domain_resolver` option.
+
+See [Dial Fields](/configuration/shared/dial/#domain_resolver) and
+[Route](/configuration/route/#default_domain_resolver).
+
+For migration,
+see [Migrate outbound DNS rule items to domain resolver](/migration/#migrate-outbound-dns-rule-items-to-domain-resolver).
+
+**3**:
+
+The new TLS fragment route options allow you to fragment TLS handshakes to bypass firewalls.
+
+This feature is intended to circumvent simple firewalls based on **plaintext packet matching**, and should not be used
+to circumvent real censorship.
+
+Since it is not designed for performance, it should not be applied to all connections, but only to server names that are
+known to be blocked.
+
+See [Route Action](/configuration/route/rule_action/#tls_fragment).
+
+**4**:
+
+New certificate options allow you to manage the default list of trusted X509 CA certificates.
+
+For the system certificate list, fixed Go not reading Android trusted certificates correctly.
+
+You can also use the Mozilla Included List instead, or add trusted certificates yourself.
+
+See [Certificate](/configuration/certificate/).
 
 ### 1.11.0
 

--- a/experimental/libbox/service.go
+++ b/experimental/libbox/service.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sagernet/sing-box"
+	box "github.com/sagernet/sing-box"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/common/process"
 	"github.com/sagernet/sing-box/common/urltest"
@@ -20,7 +20,7 @@ import (
 	"github.com/sagernet/sing-box/experimental/libbox/platform"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-tun"
+	tun "github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/control"
 	E "github.com/sagernet/sing/common/exceptions"
@@ -42,41 +42,51 @@ type BoxService struct {
 	servicePauseFields
 }
 
-func NewService(configContent string, platformInterface PlatformInterface) (*BoxService, error) {
-	ctx := BaseContext(platformInterface)
-	ctx = filemanager.WithDefault(ctx, sWorkingPath, sTempPath, sUserID, sGroupID)
-	service.MustRegister[deprecated.Manager](ctx, new(deprecatedManager))
-	options, err := parseConfig(ctx, configContent)
+type Option func(*BoxService)
+
+func NewService(configContent string, platformInterface PlatformInterface, opts ...Option) (*BoxService, error) {
+	bs := &BoxService{
+		ctx:                   BaseContext(platformInterface),
+		urlTestHistoryStorage: urltest.NewHistoryStorage(),
+	}
+	for _, opt := range opts {
+		opt(bs)
+	}
+	bs.ctx, bs.cancel = context.WithCancel(bs.ctx)
+	bs.ctx = service.ContextWithPtr(bs.ctx, &bs.urlTestHistoryStorage)
+	bs.pauseManager = service.FromContext[pause.Manager](bs.ctx)
+	bs.clashServer = service.FromContext[adapter.ClashServer](bs.ctx)
+	bs.ctx = filemanager.WithDefault(bs.ctx, sWorkingPath, sTempPath, sUserID, sGroupID)
+	service.MustRegister[deprecated.Manager](bs.ctx, new(deprecatedManager))
+	options, err := parseConfig(bs.ctx, configContent)
 	if err != nil {
+		bs.cancel()
 		return nil, err
 	}
 	runtimeDebug.FreeOSMemory()
-	ctx, cancel := context.WithCancel(ctx)
-	urlTestHistoryStorage := urltest.NewHistoryStorage()
-	ctx = service.ContextWithPtr(ctx, urlTestHistoryStorage)
+
 	platformWrapper := &platformInterfaceWrapper{
 		iif:       platformInterface,
 		useProcFS: platformInterface.UseProcFS(),
 	}
-	service.MustRegister[platform.Interface](ctx, platformWrapper)
-	instance, err := box.New(box.Options{
-		Context:           ctx,
+	service.MustRegister[platform.Interface](bs.ctx, platformWrapper)
+	bs.instance, err = box.New(box.Options{
+		Context:           bs.ctx,
 		Options:           options,
 		PlatformLogWriter: platformWrapper,
 	})
 	if err != nil {
-		cancel()
+		bs.cancel()
 		return nil, E.Cause(err, "create service")
 	}
 	runtimeDebug.FreeOSMemory()
-	return &BoxService{
-		ctx:                   ctx,
-		cancel:                cancel,
-		instance:              instance,
-		urlTestHistoryStorage: urlTestHistoryStorage,
-		pauseManager:          service.FromContext[pause.Manager](ctx),
-		clashServer:           service.FromContext[adapter.ClashServer](ctx),
-	}, nil
+	return bs, nil
+}
+
+func WithContext(ctx context.Context) Option {
+	return func(bs *BoxService) {
+		bs.ctx = ctx
+	}
 }
 
 func (s *BoxService) Start() error {


### PR DESCRIPTION
This modifies the libbox constructor in an extensible way to allow options to be configured using the functional options pattern. This particularly makes it possible to set the context such that external protocols can be registered, for example.

Note that that preserves the existing API, but allows, for example:

```go
ctx := box.Context(
    context.Background(),
    inboundRegistry,
    outboundRegistry,
    endpointRegistry,
    dnsTransportRegistry,
)
service, err := libbox.NewService(configContent, platformInterface, libbox.WithContext(ctx))
```

while still allowing the existing:

```go
service, err := libbox.NewService(configContent, platformInterface)
```