### PR TITLE
build: enable acme by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = sing-box
 COMMIT = $(shell git rev-parse --short HEAD)
-TAGS_GO120 = with_gvisor,with_dhcp,with_wireguard,with_reality_server,with_clash_api,with_quic,with_utls
+TAGS_GO120 = with_gvisor,with_dhcp,with_wireguard,with_reality_server,with_clash_api,with_quic,with_utls,with_acme
 TAGS_GO123 = with_tailscale
 TAGS ?= $(TAGS_GO120),$(TAGS_GO123)
 TAGS_TEST ?= with_gvisor,with_quic,with_wireguard,with_grpc,with_utls,with_reality_server


### PR DESCRIPTION
Simply adds a tag to Makefile to match the default tags as specified in [documentation](https://sing-box.sagernet.org/installation/build-from-source/)