### PR TITLE
Fix DNS over QUIC stream close

### DIFF
--- a/dns/transport/quic/quic.go
+++ b/dns/transport/quic/quic.go
@@ -140,12 +140,12 @@ func (t *Transport) exchange(ctx context.Context, message *mDNS.Msg, conn quic.C
 	if err != nil {
 		return nil, err
 	}
-	defer stream.Close()
-	defer stream.CancelRead(0)
 	err = transport.WriteMessage(stream, 0, message)
 	if err != nil {
+		stream.Close()
 		return nil, err
 	}
+	stream.Close()
 	return transport.ReadMessage(stream)
 }
 


### PR DESCRIPTION
Current DoQ implementation does not work with some public DoQ servers like `dns.nextdns.io`.

https://datatracker.ietf.org/doc/html/rfc9250#section-4.2-6

The client MUST send the DNS query over the selected stream and MUST indicate through the STREAM FIN mechanism that no further data will be sent on that stream.
Servers MAY defer processing of a query until the STREAM FIN has been indicated on the stream selected by the client.

Almost all main DoQ implementation are written like this, e.g. https://github.com/AdguardTeam/dnsproxy/blob/d64332fbadf25bc185d39694c68e79445a5915be/upstream/doq.go#L227-L254.

SagerNet/sing-dns#21 is for `main-next`.