### PR TITLE
fix conn copy

### DIFF
--- a/route/conn.go
+++ b/route/conn.go
@@ -262,7 +262,7 @@ func (m *ConnectionManager) connectionCopy(ctx context.Context, source net.Conn,
 			return
 		}
 	}
-	_, err := bufio.CopyWithCounters(destination, sourceReader, source, readCounters, writeCounters)
+	_, err := bufio.CopyWithCounters(destinationWriter, sourceReader, source, readCounters, writeCounters)
 	if err != nil {
 		common.Close(source, destination)
 	} else if duplexDst, isDuplex := destination.(N.WriteCloser); isDuplex {


### PR DESCRIPTION
Because the original destination conn was being passed, when using clash API, the tracker conn was getting the write function call which adds to the write counters, also the write counters were extracted and were being added to in the copy loop, which caused the clash API to report twice as much traffic as there actually was. This should fix it properly.