### PR TITLE
set error message before closing the channel

### DIFF
--- a/dns/transport/udp.go
+++ b/dns/transport/udp.go
@@ -212,8 +212,8 @@ type dnsConnection struct {
 
 func (c *dnsConnection) Close(err error) {
 	c.closeOnce.Do(func() {
-		close(c.done)
 		c.err = err
+		close(c.done)
 	})
 	c.Conn.Close()
 }


### PR DESCRIPTION
This pull request fix #2826. Avoid getting a nil error when receiving channel

https://github.com/SagerNet/sing-box/blob/b1f24b0a328f1a88011eabbfb7a852a3ebb84a04/dns/transport/udp.go#L136-L137