### PR TITLE
Mark config file as noreplace for rpm

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -7,6 +7,8 @@
 --maintainer "nekohasekai <contact-git@sekai.icu>"
 --deb-field "Bug: https://github.com/SagerNet/sing-box/issues"
 
+--config-files /etc/sing-box/config.json
+
 release/config/config.json=/etc/sing-box/config.json
 
 release/config/sing-box.service=/usr/lib/systemd/system/sing-box.service

--- a/.goreleaser.fury.yaml
+++ b/.goreleaser.fury.yaml
@@ -50,7 +50,7 @@ nfpms:
     contents:
       - src: release/config/config.json
         dst: /etc/sing-box/config.json
-        type: config
+        type: "config|noreplace"
 
       - src: release/config/sing-box.service
         dst: /usr/lib/systemd/system/sing-box.service

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,7 +132,7 @@ nfpms:
     contents:
       - src: release/config/config.json
         dst: /etc/sing-box/config.json
-        type: config
+        type: "config|noreplace"
 
       - src: release/config/sing-box.service
         dst: /usr/lib/systemd/system/sing-box.service


### PR DESCRIPTION
Prevent users' config from being replaced by rpm.