### PR TITLE
Support `GET` method for doh

### DIFF
--- a/docs/configuration/dns/server/http3.md
+++ b/docs/configuration/dns/server/http3.md
@@ -20,6 +20,7 @@ icon: material/new-box
         "server_port": 443,
         
         "path": "",
+        "method": "",
         "headers": {},
         
         "tls": {},
@@ -57,6 +58,14 @@ The port of the DNS server.
 The path of the DNS server.
 
 `/dns-query` will be used by default.
+
+#### method
+
+The method of the DNS server.
+
+Only `GET` and `POST` are supported.
+
+`POST` will be used by default.
 
 #### headers
 

--- a/docs/configuration/dns/server/https.md
+++ b/docs/configuration/dns/server/https.md
@@ -20,6 +20,7 @@ icon: material/new-box
         "server_port": 443,
         
         "path": "",
+        "method": "",
         "headers": {},
         
         "tls": {},
@@ -57,6 +58,14 @@ The port of the DNS server.
 The path of the DNS server.
 
 `/dns-query` will be used by default.
+
+#### method
+
+The method of the DNS server.
+
+Only `GET` and `POST` are supported.
+
+`POST` will be used by default.
 
 #### headers
 


### PR DESCRIPTION
rfc 8484 中定义了 doh 的 `GET` `POST` 两种请求方式，一种是 ，现有的 doh(3) 只支持 `POST` 方案进行请求，添加一个参数 `method` 以便切换 doh(3) 请求方式。