### PR TITLE
Enhance: URLTest with Concurrency Control and Faster Updates

### DIFF
--- a/docs/configuration/outbound/urltest.md
+++ b/docs/configuration/outbound/urltest.md
@@ -14,7 +14,8 @@
   "interval": "",
   "tolerance": 0,
   "idle_timeout": "",
-  "interrupt_exist_connections": false
+  "interrupt_exist_connections": false,
+  "test_concurrency": 10
 }
 ```
 
@@ -47,3 +48,7 @@ The idle timeout. `30m` will be used if empty.
 Interrupt existing connections when the selected outbound has changed.
 
 Only inbound connections are affected by this setting, internal connections will always be interrupted.
+
+#### test_concurrency
+
+URL Test concurrency. `10` will be used if empty.

--- a/docs/configuration/outbound/urltest.zh.md
+++ b/docs/configuration/outbound/urltest.zh.md
@@ -14,7 +14,8 @@
   "interval": "",
   "tolerance": 50,
   "idle_timeout": "",
-  "interrupt_exist_connections": false
+  "interrupt_exist_connections": false,
+  "test_concurrency": 10
 }
 ```
 
@@ -47,3 +48,8 @@
 当选定的出站发生更改时，中断现有连接。
 
 仅入站连接受此设置影响，内部连接将始终被中断。
+
+#### test_concurrency
+
+测试的并发连接数。 默认使用 `10`。
+

--- a/option/group.go
+++ b/option/group.go
@@ -15,4 +15,5 @@ type URLTestOutboundOptions struct {
 	Tolerance                 uint16             `json:"tolerance,omitempty"`
 	IdleTimeout               badoption.Duration `json:"idle_timeout,omitempty"`
 	InterruptExistConnections bool               `json:"interrupt_exist_connections,omitempty"`
+	TestConcurrency           uint16             `json:"test_concurrency,omitempty"`
 }

--- a/protocol/group/urltest.go
+++ b/protocol/group/urltest.go
@@ -395,6 +395,7 @@ func (g *URLTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 				resultAccess.Lock()
 				result[tag] = t
 				resultAccess.Unlock()
+				g.performUpdateCheck()
 			}
 			return nil, nil
 		})
@@ -405,6 +406,8 @@ func (g *URLTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 }
 
 func (g *URLTestGroup) performUpdateCheck() {
+	g.access.Lock()
+	defer g.access.Unlock()
 	var updated bool
 	if outbound, exists := g.Select(N.NetworkTCP); outbound != nil && (g.selectedOutboundTCP == nil || (exists && outbound != g.selectedOutboundTCP)) {
 		if g.selectedOutboundTCP != nil {


### PR DESCRIPTION
## Summary
- Introduces a `test_concurrency` option to the URLTest outbound, allowing users to specify the number of concurrent connections for testing (defaults to 10).
- Improves the responsiveness of URLTest by performing an update check after each successful individual outbound test, leading to quicker selection of the optimal outbound.