### PR TITLE
fix(docs): fix errors in the services fields

### DIFF
--- a/docs/configuration/service/index.md
+++ b/docs/configuration/service/index.md
@@ -25,6 +25,7 @@ icon: material/new-box
 |------------|------------------------|
 | `derp`     | [DERP](./derp)         |
 | `resolved` | [Resolved](./resolved) |
+| `ssm-api`  | [SSM API](./ssm-api)   |
 
 #### tag
 

--- a/docs/configuration/service/index.md
+++ b/docs/configuration/service/index.md
@@ -10,7 +10,7 @@ icon: material/new-box
 
 ```json
 {
-  "endpoints": [
+  "services": [
     {
       "type": "",
       "tag": ""


### PR DESCRIPTION
- Correct the incorrect `endpoints` in the configuration snippets in the document to `services`.
- Added the missing `ssm-api`.