### PR TITLE
fix ExtendContext

### DIFF
--- a/adapter/inbound.go
+++ b/adapter/inbound.go
@@ -126,10 +126,10 @@ func ContextFrom(ctx context.Context) *InboundContext {
 }
 
 func ExtendContext(ctx context.Context) (context.Context, *InboundContext) {
-	var newMetadata InboundContext
 	if metadata := ContextFrom(ctx); metadata != nil {
-		newMetadata = *metadata
+		return ctx, metadata
 	}
+	var newMetadata InboundContext
 	return WithContext(ctx, &newMetadata), &newMetadata
 }
 


### PR DESCRIPTION
Don't override `*InboundContext` with a new copy of it if already exist. Just return it as it is.

With existing code the ExtendContext always create a new copy of InboundContext if already exist, thus causing inconsistency when editing/reading metadata.