### PR TITLE
Fix inbound with v2ray transport missing InboundOptions

### DIFF
--- a/protocol/vless/inbound.go
+++ b/protocol/vless/inbound.go
@@ -205,6 +205,10 @@ func (h *inboundTransportHandler) NewConnectionEx(ctx context.Context, conn net.
 	var metadata adapter.InboundContext
 	metadata.Source = source
 	metadata.Destination = destination
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.InboundOptions = h.listener.ListenOptions().InboundOptions
 	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
 	(*Inbound)(h).NewConnectionEx(ctx, conn, metadata, onClose)
 }

--- a/protocol/vmess/inbound.go
+++ b/protocol/vmess/inbound.go
@@ -219,6 +219,10 @@ func (h *inboundTransportHandler) NewConnectionEx(ctx context.Context, conn net.
 	var metadata adapter.InboundContext
 	metadata.Source = source
 	metadata.Destination = destination
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.InboundOptions = h.listener.ListenOptions().InboundOptions
 	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
 	(*Inbound)(h).NewConnectionEx(ctx, conn, metadata, onClose)
 }


### PR DESCRIPTION
InboundOptions works in trojan with v2ray transport but does not work with vmess/vless with v2ray transport.

https://github.com/SagerNet/sing-box/blob/e5c6d3c080caeebc853c440360c1b3facbb168ea/protocol/trojan/inbound.go#L251-L254