### PR TITLE
Fix disable_sni not working with custom RootCAs

### DIFF
--- a/common/tls/std_client.go
+++ b/common/tls/std_client.go
@@ -86,6 +86,8 @@ func NewSTDClient(ctx context.Context, serverAddress string, options option.Outb
 		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyConnection = func(state tls.ConnectionState) error {
 			verifyOptions := x509.VerifyOptions{
+				Roots:         tlsConfig.RootCAs,
+				CurrentTime:   tlsConfig.Time(),
 				DNSName:       serverName,
 				Intermediates: x509.NewCertPool(),
 			}

--- a/common/tls/utls_client.go
+++ b/common/tls/utls_client.go
@@ -145,11 +145,16 @@ func NewUTLSClient(ctx context.Context, serverAddress string, options option.Out
 	var tlsConfig utls.Config
 	tlsConfig.Time = ntp.TimeFuncFromContext(ctx)
 	tlsConfig.RootCAs = adapter.RootPoolFromContext(ctx)
-	tlsConfig.ServerName = serverName
+	if !options.DisableSNI {
+		tlsConfig.ServerName = serverName
+	}
 	if options.Insecure {
 		tlsConfig.InsecureSkipVerify = options.Insecure
 	} else if options.DisableSNI {
-		return nil, E.New("disable_sni is unsupported in uTLS")
+		if options.Reality != nil && options.Reality.Enabled {
+			return nil, E.New("disable_sni is unsupported in reality")
+		}
+		tlsConfig.InsecureServerNameToVerify = serverName
 	}
 	if len(options.ALPN) > 0 {
 		tlsConfig.NextProtos = options.ALPN


### PR DESCRIPTION
Fix `disable_sni` not working with custom `RootCAs` and allow `disable_sni` for uTLS (but not reality).