### PR TITLE
Simplify slice to array conversions

### DIFF
--- a/common/convertor/adguard/convertor.go
+++ b/common/convertor/adguard/convertor.go
@@ -454,5 +454,5 @@ func parseADGuardIPCIDRLine(ruleLine string) (netip.Prefix, error) {
 	for len(ruleParts) < 4 {
 		ruleParts = append(ruleParts, 0)
 	}
-	return netip.PrefixFrom(netip.AddrFrom4(*(*[4]byte)(ruleParts)), bitLen), nil
+	return netip.PrefixFrom(netip.AddrFrom4([4]byte(ruleParts)), bitLen), nil
 }

--- a/common/process/searcher_darwin.go
+++ b/common/process/searcher_darwin.go
@@ -96,11 +96,11 @@ func findProcessName(network string, ip netip.Addr, port int) (string, error) {
 		switch {
 		case flag&0x1 > 0 && isIPv4:
 			// ipv4
-			srcIP = netip.AddrFrom4(*(*[4]byte)(buf[inp+76 : inp+80]))
+			srcIP = netip.AddrFrom4([4]byte(buf[inp+76 : inp+80]))
 			srcIsIPv4 = true
 		case flag&0x2 > 0 && !isIPv4:
 			// ipv6
-			srcIP = netip.AddrFrom16(*(*[16]byte)(buf[inp+64 : inp+80]))
+			srcIP = netip.AddrFrom16([16]byte(buf[inp+64 : inp+80]))
 		default:
 			continue
 		}

--- a/test/clash_darwin_test.go
+++ b/test/clash_darwin_test.go
@@ -26,7 +26,7 @@ func defaultRouteIP() (netip.Addr, error) {
 	for _, addr := range addrs {
 		ip := addr.(*net.IPNet).IP
 		if ip.To4() != nil {
-			return netip.AddrFrom4(*(*[4]byte)(ip)), nil
+			return netip.AddrFrom4([4]byte(ip)), nil
 		}
 	}
 

--- a/transport/v2raywebsocket/writer.go
+++ b/transport/v2raywebsocket/writer.go
@@ -63,7 +63,7 @@ func (w *Writer) WriteBuffer(buffer *buf.Buffer) error {
 	if !w.isServer {
 		maskKey := rand.Uint32()
 		binary.BigEndian.PutUint32(header[1+payloadBitLength:], maskKey)
-		ws.Cipher(data, *(*[4]byte)(header[1+payloadBitLength:]), 0)
+		ws.Cipher(data, [4]byte(header[1+payloadBitLength:]), 0)
 	}
 
 	return wrapWsError(w.writer.WriteBuffer(buffer))


### PR DESCRIPTION
Since Go 1.20 it's possible to convert from a slice to an array using simple syntax, see https://go.dev/ref/spec#Conversions_from_slice_to_array_or_array_pointer.