### PR TITLE
Fix libresolv initialization

### DIFF
--- a/dns/transport/local/resolv_darwin_cgo.go
+++ b/dns/transport/local/resolv_darwin_cgo.go
@@ -20,8 +20,8 @@ import (
 )
 
 func dnsReadConfig(_ context.Context, _ string) *dnsConfig {
-	var state C.res_state
-	if C.res_ninit(state) != 0 {
+	var state C.struct___res_state
+	if C.res_ninit(&state) != 0 {
 		return &dnsConfig{
 			servers:  defaultNS,
 			search:   dnsDefaultSearch(),


### PR DESCRIPTION
```C
struct __res_state;
typedef struct __res_state *res_state;
```

`var state C.res_state` is a nil pointer. `C.res_ninit(state)` always fail.