### PR TITLE
fix dns truncate

### DIFF
--- a/dns/client_truncate.go
+++ b/dns/client_truncate.go
@@ -15,8 +15,7 @@ func TruncateDNSMessage(request *dns.Msg, response *dns.Msg, headroom int) (*buf
 	}
 	responseLen := response.Len()
 	if responseLen > maxLen {
-		copyResponse := *response
-		response = &copyResponse
+		response = response.Copy()
 		response.Truncate(maxLen)
 	}
 	buffer := buf.NewSize(headroom*2 + 1 + responseLen)


### PR DESCRIPTION
The current copy method does not account for the pointer members of the dns.Msg, and changing the new copy's slice members will alter the original dns.Msg's members. This breaks the DNS cache, as truncating responses causes the message in the cache which is stored as pointer to be modified, leading to errors like `router: lookup collector.github.com: empty result (cached)` which should not happen as we do not cache empty responses.