### PR TITLE
impl: WSC protocol

### DIFF
--- a/include/registry.go
+++ b/include/registry.go
@@ -142,8 +142,8 @@ func ServiceRegistry() *service.Registry {
 }
 
 func registerStubForRemovedInbounds(registry *inbound.Registry) {
-	inbound.Register[option.ShadowsocksInboundOptions](registry, C.TypeShadowsocksR, func(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.ShadowsocksInboundOptions) (adapter.Inbound, error) {
-		return nil, E.New("ShadowsocksR is deprecated and removed in sing-box 1.6.0")
+	inbound.Register[option.ShadowsocksInboundOptions](registry, C.TypeShadowsocks, func(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.ShadowsocksInboundOptions) (adapter.Inbound, error) {
+		return nil, E.New("Shadowsocks is deprecated and removed in sing-box 1.6.0")
 	})
 }
 


### PR DESCRIPTION
This PR adds **WSC (WebSocket Connect)** transport support to sing-box, enabling tunneling of **only TCP streams** over WebSocket.

WSC is part of the **Zoro project**, a decentralized VPN network where people can help it grow by running their own Zoro nodes on VPS or dedicated servers. Users can buy Zoro accounts and bandwidth using **Ethereum**, making it an open, community-driven network that rewards contributors directly.

The reason we chose WebSocket for our project is:
* It can run behind **Cloudflare** and other CDN providers easily.
* It is more **flexible to extend** than protocols like Trojan, since it supports arguments both in **URL query parameters** and **HTTP headers**.

We didn’t use V2Ray-family protocols for Zoro because their codebases are more complex. We preferred something clean and simple, and WSC provided exactly that foundation.

This transport is simple but powerful — it lets Zoro users connect through normal HTTP/WebSocket paths, which makes it harder to block and easier to deploy anywhere.

**Credits**
Developed as part of **Zoro project**.
Special thanks to the sing-box community for the modular and clean codebase that made this possible.
