### PR TITLE
implement WSC protocol

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -19,6 +19,7 @@ const (
 	TypeTor          = "tor"
 	TypeSSH          = "ssh"
 	TypeShadowTLS    = "shadowtls"
+	TypeWSC          = "wsc"
 	TypeAnyTLS       = "anytls"
 	TypeShadowsocksR = "shadowsocksr"
 	TypeVLESS        = "vless"
@@ -73,6 +74,8 @@ func ProxyDisplayName(proxyType string) string {
 		return "SSH"
 	case TypeShadowTLS:
 		return "ShadowTLS"
+	case TypeWSC:
+		return "WSC"
 	case TypeShadowsocksR:
 		return "ShadowsocksR"
 	case TypeVLESS:

--- a/include/registry.go
+++ b/include/registry.go
@@ -3,7 +3,7 @@ package include
 import (
 	"context"
 
-	"github.com/sagernet/sing-box"
+	box "github.com/sagernet/sing-box"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
@@ -35,6 +35,7 @@ import (
 	"github.com/sagernet/sing-box/protocol/tun"
 	"github.com/sagernet/sing-box/protocol/vless"
 	"github.com/sagernet/sing-box/protocol/vmess"
+	"github.com/sagernet/sing-box/protocol/wsc"
 	"github.com/sagernet/sing-box/service/resolved"
 	"github.com/sagernet/sing-box/service/ssmapi"
 	E "github.com/sagernet/sing/common/exceptions"
@@ -61,6 +62,7 @@ func InboundRegistry() *inbound.Registry {
 	trojan.RegisterInbound(registry)
 	naive.RegisterInbound(registry)
 	shadowtls.RegisterInbound(registry)
+	wsc.RegisterInbound(registry)
 	vless.RegisterInbound(registry)
 	anytls.RegisterInbound(registry)
 
@@ -89,6 +91,7 @@ func OutboundRegistry() *outbound.Registry {
 	tor.RegisterOutbound(registry)
 	ssh.RegisterOutbound(registry)
 	shadowtls.RegisterOutbound(registry)
+	wsc.RegisterOutbound(registry)
 	vless.RegisterOutbound(registry)
 	anytls.RegisterOutbound(registry)
 

--- a/option/wsc.go
+++ b/option/wsc.go
@@ -1,0 +1,20 @@
+package option
+
+type WSCInboundOptions struct {
+	ListenOptions
+	InboundTLSOptionsContainer
+	Users []WSCUser `json:"users"`
+	Path  string
+}
+
+type WSCUser struct {
+	Auth string `json:"auth"`
+}
+
+type WSCOutboundOptions struct {
+	DialerOptions
+	ServerOptions
+	OutboundTLSOptionsContainer
+	Auth string
+	Path string
+}

--- a/protocol/wsc/conn.go
+++ b/protocol/wsc/conn.go
@@ -1,0 +1,92 @@
+package wsc
+
+import (
+	"net"
+	"time"
+
+	"github.com/sagernet/ws"
+	"github.com/sagernet/ws/wsutil"
+)
+
+type wsStreamConn struct {
+	conn   net.Conn
+	reader *wsutil.Reader
+	writer *wsutil.Writer
+	server bool
+}
+
+func newWSStreamConn(conn net.Conn, server bool) net.Conn {
+	var state ws.State
+
+	if server {
+		state = ws.StateClientSide
+	} else {
+		state = ws.StateClientSide
+	}
+
+	return &wsStreamConn{
+		conn: conn,
+		reader: &wsutil.Reader{
+			Source: conn,
+			State:  state,
+		},
+		writer: wsutil.NewWriter(conn, state, ws.OpBinary),
+		server: server,
+	}
+}
+
+func (wsConn *wsStreamConn) Read(payload []byte) (int, error) {
+	return wsConn.read(payload)
+}
+
+func (wsConn *wsStreamConn) Write(payload []byte) (int, error) {
+	return wsConn.write(payload)
+}
+
+func (wsConn *wsStreamConn) Close() error {
+	return wsConn.conn.Close()
+}
+
+func (wsConn *wsStreamConn) LocalAddr() net.Addr {
+	return wsConn.conn.LocalAddr()
+}
+
+func (wsConn *wsStreamConn) RemoteAddr() net.Addr {
+	return wsConn.conn.RemoteAddr()
+}
+
+func (wsConn *wsStreamConn) SetDeadline(dead time.Time) error {
+	return wsConn.conn.SetDeadline(dead)
+}
+
+func (wsConn *wsStreamConn) SetReadDeadline(dead time.Time) error {
+	return wsConn.conn.SetReadDeadline(dead)
+}
+
+func (wsConn *wsStreamConn) SetWriteDeadline(dead time.Time) error {
+	return wsConn.conn.SetWriteDeadline(dead)
+}
+
+func (wsConn *wsStreamConn) write(payload []byte) (int, error) {
+	if wsConn.server {
+		return len(payload), wsutil.WriteServerMessage(wsConn.conn, ws.OpBinary, payload)
+	} else {
+		return len(payload), wsutil.WriteClientMessage(wsConn.conn, ws.OpBinary, payload)
+	}
+}
+
+func (wsConn *wsStreamConn) read(payload []byte) (int, error) {
+	if wsConn.server {
+		readed, _, err := wsutil.ReadClientData(wsConn.conn)
+		if err != nil {
+			return 0, err
+		}
+		return copy(payload, readed), nil
+	} else {
+		readed, _, err := wsutil.ReadServerData(wsConn.conn)
+		if err != nil {
+			return 0, err
+		}
+		return copy(payload, readed), nil
+	}
+}

--- a/protocol/wsc/inbound.go
+++ b/protocol/wsc/inbound.go
@@ -1,0 +1,206 @@
+package wsc
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/sagernet/ws"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/tls"
+	"github.com/sagernet/sing-box/common/uot"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/sagernet/sing/common/auth"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.WSCInboundOptions](registry, C.TypeWSC, NewInbound)
+}
+
+type Inbound struct {
+	inbound.Adapter
+
+	path      string
+	router    adapter.ConnectionRouterEx
+	logger    logger.ContextLogger
+	listener  *listener.Listener
+	users     map[string]bool
+	tlsConfig tls.ServerConfig
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, opts option.WSCInboundOptions) (adapter.Inbound, error) {
+	ib := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeWSC, tag),
+		path:    opts.Path,
+		router:  uot.NewRouter(router, logger),
+		logger:  logger,
+		users:   map[string]bool{},
+	}
+
+	for _, user := range opts.Users {
+		_, ok := ib.users[user.Auth]
+		if !ok {
+			ib.users[user.Auth] = true
+		} else {
+			return nil, fmt.Errorf("user already exists: %s", user.Auth)
+		}
+	}
+
+	if ib.path == "" {
+		ib.path = "/"
+	}
+
+	var err error
+	if opts.TLS != nil {
+		ib.tlsConfig, err = tls.NewServer(ctx, logger, common.PtrValueOrDefault(opts.TLS))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ib.listener = listener.New(listener.Options{
+		Context:           ctx,
+		Logger:            logger,
+		Network:           []string{N.NetworkTCP},
+		Listen:            opts.ListenOptions,
+		ConnectionHandler: ib,
+	})
+	return ib, nil
+}
+
+func (in *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if in.tlsConfig != nil {
+		if err := in.tlsConfig.Start(); err != nil {
+			return E.Cause(err, "create TLS config")
+		}
+	}
+	return in.listener.Start()
+}
+
+func (in *Inbound) Close() error {
+	return common.Close(in.listener, in.tlsConfig)
+}
+
+func (in *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	if in.tlsConfig != nil {
+		tlsConn, err := tls.ServerHandshake(ctx, conn, in.tlsConfig)
+		if err != nil {
+			N.CloseOnHandshakeFailure(conn, onClose, err)
+			in.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source, ": TLS handshake"))
+			return
+		}
+		conn = tlsConn
+	}
+
+	var requestURI string
+	upgrader := ws.Upgrader{
+		OnRequest: func(uri []byte) error {
+			requestURI = string(uri)
+			return nil
+		},
+	}
+
+	brw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+	if _, err := upgrader.Upgrade(brw); err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, E.Cause(err, "websocket upgrade"))
+		return
+	}
+	if err := brw.Flush(); err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, E.Cause(err, "flush handshake"))
+		return
+	}
+
+	uri, err := url.ParseRequestURI(requestURI)
+	if err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, E.Cause(err, "parse request uri"))
+		return
+	}
+
+	if uri.Path != in.path {
+		N.CloseOnHandshakeFailure(conn, onClose, E.Cause(err, "invalid path"))
+		return // optional path is not allowed
+	}
+
+	query := uri.Query()
+	user := query.Get("user")
+	network := query.Get("net")
+	addr := query.Get("addr")
+
+	if _, ok := in.users[user]; !ok {
+		N.CloseOnHandshakeFailure(conn, onClose, E.New("unauthorized user"))
+		return
+	}
+
+	if network != "" && network != "tcp" && network != N.NetworkTCP {
+		N.CloseOnHandshakeFailure(conn, onClose, E.New("only net=tcp supported"))
+		return
+	}
+
+	destination, err := parseSocksAddr(addr)
+	if err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, E.Cause(err, "bad addr"))
+		return
+	}
+	metadata.Destination = destination
+
+	wsConn := newWSStreamConn(conn, true)
+
+	if user != "" {
+		ctx = auth.ContextWithUser(ctx, user)
+	}
+
+	in.router.RouteConnectionEx(ctx, wsConn, metadata, onClose)
+}
+
+func parseSocksAddr(addr string) (M.Socksaddr, error) {
+	if addr == "" {
+		return M.Socksaddr{}, E.New("empty addr")
+	}
+
+	raw := addr
+	if !strings.Contains(raw, "://") {
+		raw = "tcp://" + raw
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return M.Socksaddr{}, err
+	}
+
+	host := u.Hostname()
+	portStr := u.Port()
+	if host == "" || portStr == "" {
+		return M.Socksaddr{}, E.New("missing host or port")
+	}
+
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return M.Socksaddr{}, err
+	}
+
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return M.Socksaddr{Fqdn: host, Port: uint16(port)}, nil
+	}
+
+	return M.Socksaddr{Addr: ip, Port: uint16(port)}, nil
+}

--- a/protocol/wsc/outbound.go
+++ b/protocol/wsc/outbound.go
@@ -1,0 +1,144 @@
+package wsc
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/sagernet/ws"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/common/dialer"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+func RegisterOutbound(registry *outbound.Registry) {
+	outbound.Register(registry, C.TypeWSC, NewOutbound)
+}
+
+type Outbound struct {
+	outbound.Adapter
+
+	account    string
+	path       string
+	logger     logger.ContextLogger
+	serverAddr M.Socksaddr
+	dialer     N.Dialer
+	tlsCfg     *tls.Config
+	useTLS     bool
+}
+
+func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, opts option.WSCOutboundOptions) (adapter.Outbound, error) {
+	dialer, err := dialer.New(ctx, opts.DialerOptions, opts.ServerIsDomain())
+	if err != nil {
+		return nil, err
+	}
+
+	outbound := &Outbound{
+		Adapter: outbound.NewAdapterWithDialerOptions(
+			C.TypeWSC, tag, []string{N.NetworkTCP}, opts.DialerOptions,
+		),
+		account: opts.Auth,
+		path:    opts.Path,
+		logger:  lg,
+		dialer:  dialer,
+		useTLS:  opts.TLS.Enabled,
+	}
+
+	if outbound.path == "" {
+		outbound.path = "/"
+	}
+
+	if opts.TLS.Enabled {
+		outbound.tlsCfg = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	outbound.serverAddr = opts.ServerOptions.Build()
+	if outbound.serverAddr.Port == 0 {
+		return nil, errors.New("port is not specified")
+	}
+	return outbound, nil
+}
+
+func (out *Outbound) Type() string {
+	return C.TypeWSC
+}
+
+func (out *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	if network != N.NetworkTCP {
+		return nil, errors.New("wsc: only TCP is supported")
+	}
+
+	host := out.serverAddr.Fqdn
+	port := out.serverAddr.Port
+
+	if host == "" && out.serverAddr.Fqdn == "" {
+		host = out.serverAddr.Addr.String()
+	}
+
+	scheme := "ws"
+	if out.useTLS {
+		scheme = "wss"
+	}
+
+	uri := url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(host, fmt.Sprint(port)),
+		Path:   "/wsc",
+	}
+
+	query := uri.Query()
+	query.Set("user", out.account)
+	query.Set("net", "tcp")
+	query.Set("addr", destination.String())
+	uri.RawQuery = query.Encode()
+
+	wsDialer := ws.Dialer{
+		NetDial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(address)
+			if err != nil {
+				return nil, err
+			}
+
+			portInt, err := strconv.ParseUint(port, 10, 16)
+			if err != nil {
+				return nil, err
+			}
+
+			return out.dialer.DialContext(ctx, N.NetworkTCP, M.Socksaddr{
+				Fqdn: host,
+				Port: uint16(portInt),
+			})
+		},
+	}
+
+	if out.useTLS && out.tlsCfg != nil {
+		if (*out.tlsCfg).ServerName == "" {
+			(*out.tlsCfg).ServerName = host
+		}
+		wsDialer.TLSConfig = out.tlsCfg
+	}
+
+	wsConn, _, _, err := wsDialer.Dial(ctx, uri.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return newWSStreamConn(wsConn, false), nil
+}
+
+func (out *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	return nil, errors.New("wsc: UDP is not supported")
+}


### PR DESCRIPTION
This PR adds **WSC (WebSocket Connect)** protocol support to sing-box, enabling tunneling of **only TCP streams** over WebSocket.

WSC is part of the **Zoro project**, a decentralized VPN network where people can help it grow by running their own Zoro nodes on VPS or dedicated servers. Users can buy Zoro accounts and bandwidth using **Ethereum**, making it an open, community-driven network that rewards contributors directly.

The reason we chose WebSocket for our project is:
* It can run behind **Cloudflare** and other CDN providers easily.
* It is more **flexible to extend** than protocols like Trojan, since it supports arguments both in **URL query parameters** and **HTTP headers**.

We didn’t use V2Ray-family protocols for Zoro because their codebases are more complex. We preferred something clean and simple, and WSC provided exactly that foundation.

This transport is simple but powerful — it lets Zoro users connect through normal HTTP/WebSocket paths, which makes it harder to block and easier to deploy anywhere.

**Credits**
Developed as part of **Zoro project**.
Special thanks to the sing-box community for the modular and clean codebase that made this possible.
