### PR TITLE
Add `domain_wildcard` rule type

### DIFF
--- a/common/srs/binary.go
+++ b/common/srs/binary.go
@@ -27,6 +27,7 @@ const (
 	ruleItemDomain
 	ruleItemDomainKeyword
 	ruleItemDomainRegex
+	ruleItemDomainWildcard
 	ruleItemSourceIPCIDR
 	ruleItemIPCIDR
 	ruleItemSourcePort
@@ -182,6 +183,8 @@ func readDefaultRule(reader varbin.Reader, recover bool) (rule option.DefaultHea
 			rule.DomainKeyword, err = readRuleItemString(reader)
 		case ruleItemDomainRegex:
 			rule.DomainRegex, err = readRuleItemString(reader)
+		case ruleItemDomainWildcard:
+			rule.DomainWildcard, err = readRuleItemString(reader)
 		case ruleItemSourceIPCIDR:
 			rule.SourceIPSet, err = readIPSet(reader)
 			if err != nil {
@@ -329,6 +332,12 @@ func writeDefaultRule(writer varbin.Writer, rule option.DefaultHeadlessRule, gen
 	}
 	if len(rule.DomainRegex) > 0 {
 		err = writeRuleItemString(writer, ruleItemDomainRegex, rule.DomainRegex)
+		if err != nil {
+			return err
+		}
+	}
+	if len(rule.DomainWildcard) > 0 {
+		err = writeRuleItemString(writer, ruleItemDomainWildcard, rule.DomainWildcard)
 		if err != nil {
 			return err
 		}

--- a/docs/configuration/dns/rule.md
+++ b/docs/configuration/dns/rule.md
@@ -6,7 +6,8 @@ icon: material/alert-decagram
 
     :material-plus: [interface_address](#interface_address)  
     :material-plus: [network_interface_address](#network_interface_address)  
-    :material-plus: [default_interface_address](#default_interface_address)
+    :material-plus: [default_interface_address](#default_interface_address)  
+    :material-plus: [domain_wildcard](#domain_wildcard)
 
 !!! quote "Changes in sing-box 1.12.0"
 
@@ -83,6 +84,9 @@ icon: material/alert-decagram
         ],
         "domain_regex": [
           "^stun\\..+"
+        ],
+        "domain_wildcard": [
+          "a*.test.com"
         ],
         "source_ip_cidr": [
           "10.0.0.0/24",
@@ -203,7 +207,7 @@ icon: material/alert-decagram
 !!! note ""
 
     The default rule uses the following matching logic:  
-    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `geosite`) &&  
+    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `domain_wildcard` || `geosite`) &&  
     (`port` || `port_range`) &&  
     (`source_geoip` || `source_ip_cidr` ｜｜ `source_ip_is_private`) &&  
     (`source_port` || `source_port_range`) &&  
@@ -252,6 +256,12 @@ Match domain using keyword.
 #### domain_regex
 
 Match domain using regular expression.
+
+### domain_wildcard
+
+!!! question "Since sing-box 1.13.0"
+
+Match domain using wildcard expression.
 
 #### geosite
 

--- a/docs/configuration/dns/rule.zh.md
+++ b/docs/configuration/dns/rule.zh.md
@@ -6,7 +6,8 @@ icon: material/alert-decagram
 
     :material-plus: [interface_address](#interface_address)  
     :material-plus: [network_interface_address](#network_interface_address)  
-    :material-plus: [default_interface_address](#default_interface_address)
+    :material-plus: [default_interface_address](#default_interface_address)  
+    :material-plus: [domain_wildcard](#domain_wildcard)
 
 !!! quote "sing-box 1.12.0 中的更改"
 
@@ -83,6 +84,9 @@ icon: material/alert-decagram
         ],
         "domain_regex": [
           "^stun\\..+"
+        ],
+        "domain_wildcard": [
+          "a*.test.com"
         ],
         "source_ip_cidr": [
           "10.0.0.0/24",
@@ -202,7 +206,7 @@ icon: material/alert-decagram
 !!! note ""
 
     默认规则使用以下匹配逻辑:  
-    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `geosite`) &&  
+    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `domain_wildcard` || `geosite`) &&  
     (`port` || `port_range`) &&  
     (`source_geoip` || `source_ip_cidr` || `source_ip_is_private`) &&  
     (`source_port` || `source_port_range`) &&  
@@ -251,6 +255,12 @@ DNS 查询类型。值可以为整数或者类型名称字符串。
 #### domain_regex
 
 匹配域名正则表达式。
+
+### domain_wildcard
+
+!!! question "自 sing-box 1.13.0 起"
+
+匹配域名通配符表达式。
 
 #### geosite
 

--- a/docs/configuration/route/rule.md
+++ b/docs/configuration/route/rule.md
@@ -8,6 +8,7 @@ icon: material/new-box
     :material-plus: [network_interface_address](#network_interface_address)  
     :material-plus: [default_interface_address](#default_interface_address)  
     :material-plus: [preferred_by](#preferred_by)  
+    :material-plus: [domain_wildcard](#domain_wildcard)  
     :material-alert: [network](#network)
 
 !!! quote "Changes in sing-box 1.11.0"
@@ -75,6 +76,9 @@ icon: material/new-box
         ],
         "domain_regex": [
           "^stun\\..+"
+        ],
+        "domain_wildcard": [
+          "a*.test.com"
         ],
         "geosite": [
           "cn"
@@ -193,7 +197,7 @@ icon: material/new-box
 !!! note ""
 
     The default rule uses the following matching logic:  
-    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `geosite` || `geoip` || `ip_cidr` || `ip_is_private`) &&  
+    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `domain_wildcard` || `geosite` || `geoip` || `ip_cidr` || `ip_is_private`) &&  
     (`port` || `port_range`) &&  
     (`source_geoip` || `source_ip_cidr` || `source_ip_is_private`) &&  
     (`source_port` || `source_port_range`) &&  
@@ -252,6 +256,12 @@ Match domain using keyword.
 #### domain_regex
 
 Match domain using regular expression.
+
+### domain_wildcard
+
+!!! question "Since sing-box 1.13.0"
+
+Match domain using wildcard expression.
 
 #### geosite
 

--- a/docs/configuration/route/rule.zh.md
+++ b/docs/configuration/route/rule.zh.md
@@ -8,6 +8,7 @@ icon: material/new-box
     :material-plus: [network_interface_address](#network_interface_address)  
     :material-plus: [default_interface_address](#default_interface_address)  
     :material-plus: [preferred_by](#preferred_by)  
+    :material-plus: [domain_wildcard](#domain_wildcard)  
     :material-alert: [network](#network)
 
 !!! quote "sing-box 1.11.0 中的更改"
@@ -74,6 +75,9 @@ icon: material/new-box
         ],
         "domain_regex": [
           "^stun\\..+"
+        ],
+        "domain_wildcard": [
+          "a*.test.com"
         ],
         "geosite": [
           "cn"
@@ -190,7 +194,7 @@ icon: material/new-box
 !!! note ""
 
     默认规则使用以下匹配逻辑:  
-    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `geosite` || `geoip` || `ip_cidr` || `ip_is_private`) &&  
+    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `domain_wildcard` || `geosite` || `geoip` || `ip_cidr` || `ip_is_private`) &&  
     (`port` || `port_range`) &&  
     (`source_geoip` || `source_ip_cidr` || `source_ip_is_private`) &&  
     (`source_port` || `source_port_range`) &&  
@@ -249,6 +253,12 @@ icon: material/new-box
 #### domain_regex
 
 匹配域名正则表达式。
+
+### domain_wildcard
+
+!!! question "自 sing-box 1.13.0 起"
+
+匹配域名通配符表达式。
 
 #### geosite
 

--- a/docs/configuration/rule-set/headless-rule.md
+++ b/docs/configuration/rule-set/headless-rule.md
@@ -5,7 +5,8 @@ icon: material/new-box
 !!! quote "Changes in sing-box 1.13.0"
 
     :material-plus: [network_interface_address](#network_interface_address)  
-    :material-plus: [default_interface_address](#default_interface_address)
+    :material-plus: [default_interface_address](#default_interface_address)  
+    :material-plus: [domain_wildcard](#domain_wildcard)
 
 !!! quote "Changes in sing-box 1.11.0"
 
@@ -40,6 +41,9 @@ icon: material/new-box
       ],
       "domain_regex": [
         "^stun\\..+"
+      ],
+      "domain_wildcard": [
+        "a*.test.com"
       ],
       "source_ip_cidr": [
         "10.0.0.0/24",
@@ -118,7 +122,7 @@ icon: material/new-box
 !!! note ""
 
     The default rule uses the following matching logic:  
-    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `ip_cidr`) &&  
+    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `domain_wildcard` || `ip_cidr`) &&  
     (`port` || `port_range`) &&  
     (`source_port` || `source_port_range`) &&  
     `other fields`
@@ -146,6 +150,12 @@ Match domain using keyword.
 #### domain_regex
 
 Match domain using regular expression.
+
+### domain_wildcard
+
+!!! question "Since sing-box 1.13.0"
+
+Match domain using wildcard expression.
 
 #### source_ip_cidr
 

--- a/docs/configuration/rule-set/headless-rule.zh.md
+++ b/docs/configuration/rule-set/headless-rule.zh.md
@@ -5,7 +5,8 @@ icon: material/new-box
 !!! quote "sing-box 1.13.0 中的更改"
 
     :material-plus: [network_interface_address](#network_interface_address)  
-    :material-plus: [default_interface_address](#default_interface_address)
+    :material-plus: [default_interface_address](#default_interface_address)  
+    :material-plus: [domain_wildcard](#domain_wildcard)
 
 !!! quote "sing-box 1.11.0 中的更改"
 
@@ -40,6 +41,9 @@ icon: material/new-box
       ],
       "domain_regex": [
         "^stun\\..+"
+      ],
+      "domain_wildcard": [
+        "a*.test.com"
       ],
       "source_ip_cidr": [
         "10.0.0.0/24",
@@ -118,7 +122,7 @@ icon: material/new-box
 !!! note ""
 
     默认规则使用以下匹配逻辑:  
-    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `ip_cidr`) &&  
+    (`domain` || `domain_suffix` || `domain_keyword` || `domain_regex` || `domain_wildcard` || `ip_cidr`) &&  
     (`port` || `port_range`) &&  
     (`source_port` || `source_port_range`) &&  
     `other fields`
@@ -146,6 +150,12 @@ DNS 查询类型。值可以为整数或者类型名称字符串。
 #### domain_regex
 
 匹配域名正则表达式。
+
+### domain_wildcard
+
+!!! question "自 sing-box 1.13.0 起"
+
+匹配域名通配符表达式。
 
 #### source_ip_cidr
 

--- a/option/rule.go
+++ b/option/rule.go
@@ -76,6 +76,7 @@ type RawDefaultRule struct {
 	Domain                   badoption.Listable[string]                                                  `json:"domain,omitempty"`
 	DomainSuffix             badoption.Listable[string]                                                  `json:"domain_suffix,omitempty"`
 	DomainKeyword            badoption.Listable[string]                                                  `json:"domain_keyword,omitempty"`
+	DomainWildcard           badoption.Listable[string]                                                  `json:"domain_wildcard,omitempty"`
 	DomainRegex              badoption.Listable[string]                                                  `json:"domain_regex,omitempty"`
 	Geosite                  badoption.Listable[string]                                                  `json:"geosite,omitempty"`
 	SourceGeoIP              badoption.Listable[string]                                                  `json:"source_geoip,omitempty"`

--- a/option/rule_dns.go
+++ b/option/rule_dns.go
@@ -77,6 +77,7 @@ type RawDefaultDNSRule struct {
 	Domain                   badoption.Listable[string]                                                  `json:"domain,omitempty"`
 	DomainSuffix             badoption.Listable[string]                                                  `json:"domain_suffix,omitempty"`
 	DomainKeyword            badoption.Listable[string]                                                  `json:"domain_keyword,omitempty"`
+	DomainWildcard           badoption.Listable[string]                                                  `json:"domain_wildcard,omitempty"`
 	DomainRegex              badoption.Listable[string]                                                  `json:"domain_regex,omitempty"`
 	Geosite                  badoption.Listable[string]                                                  `json:"geosite,omitempty"`
 	SourceGeoIP              badoption.Listable[string]                                                  `json:"source_geoip,omitempty"`

--- a/option/rule_set.go
+++ b/option/rule_set.go
@@ -188,6 +188,7 @@ type DefaultHeadlessRule struct {
 	DomainSuffix            badoption.Listable[string]                                                  `json:"domain_suffix,omitempty"`
 	DomainKeyword           badoption.Listable[string]                                                  `json:"domain_keyword,omitempty"`
 	DomainRegex             badoption.Listable[string]                                                  `json:"domain_regex,omitempty"`
+	DomainWildcard          badoption.Listable[string]                                                  `json:"domain_wildcard,omitempty"`
 	SourceIPCIDR            badoption.Listable[string]                                                  `json:"source_ip_cidr,omitempty"`
 	IPCIDR                  badoption.Listable[string]                                                  `json:"ip_cidr,omitempty"`
 	SourcePort              badoption.Listable[uint16]                                                  `json:"source_port,omitempty"`

--- a/route/rule/rule_default.go
+++ b/route/rule/rule_default.go
@@ -122,6 +122,11 @@ func NewDefaultRule(ctx context.Context, logger log.ContextLogger, options optio
 		rule.destinationAddressItems = append(rule.destinationAddressItems, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.DomainWildcard) > 0 {
+		item := NewDomainWildcardItem(options.DomainWildcard)
+		rule.destinationAddressItems = append(rule.destinationAddressItems, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.Geosite) > 0 {
 		return nil, E.New("geosite database is deprecated in sing-box 1.8.0 and removed in sing-box 1.12.0")
 	}

--- a/route/rule/rule_dns.go
+++ b/route/rule/rule_dns.go
@@ -113,6 +113,11 @@ func NewDefaultDNSRule(ctx context.Context, logger log.ContextLogger, options op
 		rule.destinationAddressItems = append(rule.destinationAddressItems, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.DomainWildcard) > 0 {
+		item := NewDomainWildcardItem(options.DomainWildcard)
+		rule.destinationAddressItems = append(rule.destinationAddressItems, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.Geosite) > 0 {
 		return nil, E.New("geosite database is deprecated in sing-box 1.8.0 and removed in sing-box 1.12.0")
 	}

--- a/route/rule/rule_headless.go
+++ b/route/rule/rule_headless.go
@@ -71,6 +71,11 @@ func NewDefaultHeadlessRule(ctx context.Context, options option.DefaultHeadlessR
 		rule.destinationAddressItems = append(rule.destinationAddressItems, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.DomainWildcard) > 0 {
+		item := NewDomainWildcardItem(options.DomainWildcard)
+		rule.destinationAddressItems = append(rule.destinationAddressItems, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.SourceIPCIDR) > 0 {
 		item, err := NewIPCIDRItem(true, options.SourceIPCIDR)
 		if err != nil {

--- a/route/rule/rule_item_domain_wildcard.go
+++ b/route/rule/rule_item_domain_wildcard.go
@@ -1,0 +1,79 @@
+package rule
+
+import (
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+)
+
+var _ RuleItem = (*DomainWildcardItem)(nil)
+
+type DomainWildcardItem struct {
+	wildcards []string
+}
+
+func NewDomainWildcardItem(wildcards []string) *DomainWildcardItem {
+	// lowercase all wildcards for case-insensitive matching
+	for i, w := range wildcards {
+		wildcards[i] = strings.ToLower(w)
+	}
+	return &DomainWildcardItem{wildcards}
+}
+
+func (r *DomainWildcardItem) Match(metadata *adapter.InboundContext) bool {
+	var domainHost string
+	if metadata.Domain != "" {
+		domainHost = metadata.Domain
+	} else {
+		domainHost = metadata.Destination.Fqdn
+	}
+	if domainHost == "" {
+		return false
+	}
+	domainHost = strings.ToLower(domainHost)
+	for _, wildcard := range r.wildcards {
+		if matchTwoPointers(domainHost, wildcard) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *DomainWildcardItem) String() string {
+	kLen := len(r.wildcards)
+	if kLen == 1 {
+		return "domain_wildcard=" + r.wildcards[0]
+	} else if kLen > 3 {
+		return "domain_wildcard=[" + strings.Join(r.wildcards[:3], " ") + "...]"
+	} else {
+		return "domain_wildcard=[" + strings.Join(r.wildcards, " ") + "]"
+	}
+}
+
+// matchTwoPointers checks if the domain matches the pattern with wildcards.
+// The pattern can contain '?' which matches any single character and '*' which matches any sequence of characters (including the empty sequence).
+func matchTwoPointers(domain, pattern string) bool {
+	si, pi := 0, 0
+	star, match := -1, 0
+
+	for si < len(domain) {
+		if pi < len(pattern) && (pattern[pi] == domain[si] || pattern[pi] == '?') {
+			si++
+			pi++
+		} else if pi < len(pattern) && pattern[pi] == '*' {
+			star = pi
+			match = si
+			pi++
+		} else if star != -1 {
+			pi = star + 1
+			match++
+			si = match
+		} else {
+			return false
+		}
+	}
+	for pi < len(pattern) && pattern[pi] == '*' {
+		pi++
+	}
+	return pi == len(pattern)
+}


### PR DESCRIPTION
### Overview
This PR introduces a two-pointer based wildcard matching algorithm to handle domain matching patterns.
It can replace some simple regular expression use cases for better performance and readability.
### Algorithm Description
Supports:
  `* → matches any sequence of characters (including empty)`
  `? → matches exactly one arbitrary character`
```golang
matchTwoPointers("example.com", "example.com")        // true
matchTwoPointers("sub.example.com", "*.example.com")  // true
matchTwoPointers("test.example.org", "*.example.com") // false
matchTwoPointers("mail.google.com", "*google.com")    // true
matchTwoPointers("api.github.io", "api.?ithub.io")    // true
matchTwoPointers("cdn01.site.net", "cdn*.site.net")   // true
matchTwoPointers("localhost", "*")                    // true
matchTwoPointers("test", "t*st")                      // true
matchTwoPointers("text", "t?st")                      // false
```