### PR TITLE
Add YAML configuration support

### DIFF
--- a/cmd/sing-box/cmd_format.go
+++ b/cmd/sing-box/cmd_format.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 
 	"github.com/sagernet/sing-box/log"
 	E "github.com/sagernet/sing/common/exceptions"
-	"github.com/sagernet/sing/common/json"
+	singJson "github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/common/json/badjson"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var commandFormatFlagWrite bool
@@ -42,29 +44,52 @@ func format() error {
 		if err != nil {
 			return err
 		}
-		buffer := new(bytes.Buffer)
-		encoder := json.NewEncoder(buffer)
-		encoder.SetIndent("", "  ")
-		err = encoder.Encode(optionsEntry.options)
-		if err != nil {
-			return E.Cause(err, "encode config")
+
+		var formattedContent []byte
+		isYAML := isYAMLFile(optionsEntry.path)
+
+		if isYAML {
+			// Format as YAML
+			var data interface{}
+			err = json.Unmarshal(optionsEntry.content, &data)
+			if err != nil {
+				return E.Cause(err, "unmarshal config for YAML formatting")
+			}
+			formattedContent, err = yaml.Marshal(data)
+			if err != nil {
+				return E.Cause(err, "encode config as YAML")
+			}
+		} else {
+			// Format as JSON
+			buffer := new(bytes.Buffer)
+			encoder := singJson.NewEncoder(buffer)
+			encoder.SetIndent("", "  ")
+			err = encoder.Encode(optionsEntry.options)
+			if err != nil {
+				return E.Cause(err, "encode config")
+			}
+			formattedContent = buffer.Bytes()
 		}
+
 		outputPath, _ := filepath.Abs(optionsEntry.path)
 		if !commandFormatFlagWrite {
 			if len(optionsList) > 1 {
 				os.Stdout.WriteString(outputPath + "\n")
 			}
-			os.Stdout.WriteString(buffer.String() + "\n")
+			os.Stdout.Write(formattedContent)
+			if !isYAML {
+				os.Stdout.WriteString("\n")
+			}
 			continue
 		}
-		if bytes.Equal(optionsEntry.content, buffer.Bytes()) {
+		if bytes.Equal(optionsEntry.content, formattedContent) {
 			continue
 		}
 		output, err := os.Create(optionsEntry.path)
 		if err != nil {
 			return E.Cause(err, "open output")
 		}
-		_, err = output.Write(buffer.Bytes())
+		_, err = output.Write(formattedContent)
 		output.Close()
 		if err != nil {
 			return E.Cause(err, "write output")

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -1,0 +1,27 @@
+log:
+  level: info
+
+dns:
+  servers:
+    - address: tls://8.8.8.8
+
+inbounds:
+  - type: shadowsocks
+    listen: "::"
+    listen_port: 8080
+    network: tcp
+    method: 2022-blake3-aes-128-gcm
+    password: "Gn1JUS14bLUHgv1cWDDp4A=="
+    multiplex:
+      enabled: true
+      padding: true
+
+outbounds:
+  - type: direct
+  - type: dns
+    tag: dns-out
+
+route:
+  rules:
+    - port: 53
+      outbound: dns-out


### PR DESCRIPTION
This commit adds comprehensive YAML support to sing-box, allowing users to use YAML files (.yaml/.yml) in addition to JSON for configuration.

Changes:
- Added yaml.v3 import to all relevant command files
- Implemented YAML to JSON conversion pipeline
- Updated config file detection to accept .yaml and .yml extensions
- Modified readConfigAt() to automatically detect and convert YAML files
- Updated directory scanning to include YAML files alongside JSON
- Enhanced format command to preserve original file format (YAML->YAML, JSON->JSON)
- Updated rule-set commands (compile, merge) to support YAML input
- Added test-config.yaml as an example YAML configuration

The implementation converts YAML to JSON internally, leveraging the existing JSON parsing infrastructure while providing a seamless YAML user experience.