### PR TITLE
fix(dns): reset buffer in dhcp response loop

### DIFF
--- a/dns/transport/dhcp/dhcp.go
+++ b/dns/transport/dhcp/dhcp.go
@@ -263,6 +263,7 @@ func (t *Transport) fetchServersResponse(iface *control.Interface, packetConn ne
 	defer buffer.Release()
 
 	for {
+		buffer.Reset()
 		_, _, err := buffer.ReadPacketFrom(packetConn)
 		if err != nil {
 			if errors.Is(err, io.ErrShortBuffer) {


### PR DESCRIPTION
Previously, the buffer was not reset within the response loop. If a packet handle failed or completed, the buffer retained its state. Specifically, if `ReadPacketFrom` returned `io.ErrShortBuffer`, the error was ignored via `continue`, but the buffer remained full. This caused the next read attempt to immediately fail with the same error, creating a tight busy-wait loop that consumed 100% CPU.

Validates `buffer.Reset()` is called at the start of each iteration to ensure a clean state for `ReadPacketFrom`.