### PR TITLE
fix: ensure sing-box service wait for network online

### DIFF
--- a/release/config/sing-box.service
+++ b/release/config/sing-box.service
@@ -2,6 +2,7 @@
 Description=sing-box service
 Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target network-online.target
+Wants=network-online.target
 
 [Service]
 User=sing-box

--- a/release/config/sing-box@.service
+++ b/release/config/sing-box@.service
@@ -2,6 +2,7 @@
 Description=sing-box service
 Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target network-online.target
+Wants=network-online.target
 
 [Service]
 User=sing-box

--- a/release/local/sing-box.service
+++ b/release/local/sing-box.service
@@ -2,6 +2,7 @@
 Description=sing-box service
 Documentation=https://sing-box.sagernet.org
 After=network.target nss-lookup.target network-online.target
+Wants=network-online.target
 
 [Service]
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_PTRACE CAP_DAC_READ_SEARCH


### PR DESCRIPTION
Using a DNS server of type `dhcp` on Linux may lead to the following error during startup, we should ensure sing-box service wait for network online by adding `network-online.target` dependency:

```console
ERROR[0000] network: missing default interface
ERROR[0000] dns/dhcp[local]: fetch DNS servers: dhcp: prepare interface: missing default interface
```
