### PR TITLE
Feat: HTTP client supporting Brotli Content-Encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sagernet/sing-box
 go 1.23.1
 
 require (
+	github.com/andybalholm/brotli v1.2.0
 	github.com/anytls/sing-anytls v0.0.11
 	github.com/caddyserver/certmagic v0.23.0
 	github.com/coder/websocket v1.8.13
@@ -62,7 +63,6 @@ require (
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
-	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/bits-and-blooms/bitset v1.13.0 // indirect
 	github.com/caddyserver/zerossl v0.1.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7V
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anytls/sing-anytls v0.0.11 h1:w8e9Uj1oP3m4zxkyZDewPk0EcQbvVxb7Nn+rapEx4fc=
 github.com/anytls/sing-anytls v0.0.11/go.mod h1:7rjN6IukwysmdusYsrV51Fgu1uW6vsrdd6ctjnEAln8=
 github.com/bits-and-blooms/bitset v1.13.0 h1:bAQ9OPNFYbGHV6Nez0tmNI0RiEu7/hxlYJRUA0wFAVE=


### PR DESCRIPTION
I found that `brotli` is already an indirect dependency, so this PR adds a support for `Content-Encoding: br`.

Tested by this example:
```go
package main

import (
        "net/http"

        "github.com/andybalholm/brotli"
)

func main() {
        http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
                data := `{"version":1,"rules":[{"domain_suffix":["alphabet.com"],"domain_keyword":["fitbit","google"]}]}`
                w.Header().Set("Content-Encoding", "br")
                w.Header().Set("Content-Type", "application/json")
                bw := brotli.NewWriter(w)
                defer bw.Close()
                bw.Write([]byte(data))
        })
        panic(http.ListenAndServe("127.0.0.1:1408", nil))
}
```

sing-box logs and config file:
```console
➜ ./sing-box run -c test.json; cat test.json 
INFO[0000] network: updated default interface enp7s0, index 2
DEBUG[0000] router: updating rule-set test from URL: http://127.0.0.1:1408
INFO[0000] outbound/direct: outbound connection to 127.0.0.1:1408
INFO[0000] router: updated rule-set test
INFO[0000] sing-box started (0.00s)
^C{
  "route": {
    "rule_set": [
      {
        "type": "remote",
        "tag": "test",
        "format": "source",
        "url": "http://127.0.0.1:1408"
      }
    ]
  }
}
```
But it's only in `rule_set_remote.go` and `router.go`, and wrote by some random AI that's not me.

If this PR doesn't meet the standards, feel free to just close it.