### PR TITLE
make: fix binary path in clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ docs_install:
 
 clean:
 	rm -rf bin dist sing-box
-	rm -f $(shell go env GOPATH)/sing-box
+	rm -f $(PREFIX)/bin/$(NAME)
 
 update:
 	git fetch


### PR DESCRIPTION
`install` target copies binary into `$(PREFIX)/bin/` directory but `clean` target attempts to remove it from `$(PREFIX)`.
This commit updates the `clean` target to use the same path as `install` target so it can correctly uninstall the program.