### PR TITLE
Fix IPv6 local DNS on Windows

### DIFF
--- a/dns/transport/local/resolv_windows.go
+++ b/dns/transport/local/resolv_windows.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"strconv"
 	"syscall"
 	"time"
 	"unsafe"
@@ -63,6 +64,9 @@ func dnsReadConfig(ctx context.Context, _ string) *dnsConfig {
 					continue
 				}
 				dnsServerAddr = netip.AddrFrom16(sockaddr.Addr)
+				if sockaddr.ZoneId != 0 {
+					dnsServerAddr = dnsServerAddr.WithZone(strconv.FormatInt(int64(sockaddr.ZoneId), 10))
+				}
 			default:
 				// Unexpected type.
 				continue


### PR DESCRIPTION
IPv6 Zone ID needs to be preserved.

Go standard library does not have this issue because they don't use the addresses directly.
https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/net/lookup_windows.go#L124-L153