### PR TITLE
fix: close hijacked websocket conn in getConnections

### DIFF
--- a/experimental/clashapi/connections.go
+++ b/experimental/clashapi/connections.go
@@ -38,6 +38,7 @@ func getConnections(ctx context.Context, trafficManager *trafficontrol.Manager) 
 		if err != nil {
 			return
 		}
+		defer conn.Close()
 
 		intervalStr := r.URL.Query().Get("interval")
 		interval := 1000

--- a/experimental/clashapi/server.go
+++ b/experimental/clashapi/server.go
@@ -115,7 +115,7 @@ func NewServer(ctx context.Context, logFactory log.ObservableFactory, options op
 	chiRouter.Group(func(r chi.Router) {
 		r.Use(authentication(options.Secret))
 		r.Get("/", hello(options.ExternalUI != ""))
-		r.Get("/logs", getLogs(logFactory))
+		r.Get("/logs", getLogs(s.ctx, logFactory))
 		r.Get("/traffic", traffic(s.ctx, trafficManager))
 		r.Get("/version", version)
 		r.Mount("/configs", configRouter(s, logFactory))
@@ -360,7 +360,7 @@ type Log struct {
 	Payload string `json:"payload"`
 }
 
-func getLogs(logFactory log.ObservableFactory) func(w http.ResponseWriter, r *http.Request) {
+func getLogs(ctx context.Context, logFactory log.ObservableFactory) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		levelText := r.URL.Query().Get("level")
 		if levelText == "" {
@@ -399,6 +399,8 @@ func getLogs(logFactory log.ObservableFactory) func(w http.ResponseWriter, r *ht
 		var logEntry log.Entry
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case <-done:
 				return
 			case logEntry = <-subscription:


### PR DESCRIPTION
ws.UpgradeHTTP hijacks the TCP connection from the HTTP server, so http.Server.Close() will not close it. Without an explicit conn.Close(), the connection leaks when the handler returns (e.g. on context cancellation or write error).

Add defer conn.Close() to match the existing pattern in the traffic() handler in server.go.

-----------

support context cancellation in getConnections and getLogs
    
getConnections() used `for range tick.C` which does not respond to
context cancellation, leaving the goroutine and hijacked websocket
connection alive after SIGHUP config reload until the client disconnects.

getLogs() had a `<-done` channel from logFactory but no ctx.Done(),
so if logFactory outlives the server the goroutine would not exit
promptly on shutdown.

Add ctx.Done() select case to both handlers for timely cleanup.