### PR TITLE
Add DisableDNSHijack option to TunInboundOptions

### DIFF
--- a/option/tun.go
+++ b/option/tun.go
@@ -41,6 +41,7 @@ type TunInboundOptions struct {
 	ExcludePackage                badoption.Listable[string]       `json:"exclude_package,omitempty"`
 	UDPTimeout                    UDPTimeoutCompat                 `json:"udp_timeout,omitempty"`
 	Stack                         string                           `json:"stack,omitempty"`
+	DisableDNSHijack              bool                             `json:"disable_dnshijack,omitempty"`
 	Platform                      *TunPlatformOptions              `json:"platform,omitempty"`
 	InboundOptions
 

--- a/protocol/tun/inbound.go
+++ b/protocol/tun/inbound.go
@@ -234,6 +234,7 @@ func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLo
 			ExcludePackage:                        options.ExcludePackage,
 			InterfaceMonitor:                      networkManager.InterfaceMonitor(),
 			EXP_MultiPendingPackets:               multiPendingPackets,
+			EXP_DisableDNSHijack:                  options.DisableDNSHijack,
 		},
 		udpTimeout:        udpTimeout,
 		stack:             options.Stack,


### PR DESCRIPTION
Sometimes we need to disable the default dns hijack rule so that we can add custom rules. Otherwise, auto_redirect will always override the original destination address for port 53.