### PR TITLE
option: add tcp_keep_alive_count for TCP keepalive probe count

### DIFF
--- a/common/dialer/default.go
+++ b/common/dialer/default.go
@@ -158,10 +158,15 @@ func NewDefault(ctx context.Context, options option.DialerOptions) (*DefaultDial
 		if keepInterval == 0 {
 			keepInterval = C.TCPKeepAliveInterval
 		}
+		keepCount := options.TCPKeepAliveCount
+		if keepCount < 0 {
+			keepCount = 0
+		}
 		dialer.KeepAliveConfig = net.KeepAliveConfig{
 			Enable:   true,
 			Idle:     keepIdle,
 			Interval: keepInterval,
+			Count:    keepCount,
 		}
 	}
 	var udpFragment bool

--- a/common/listener/listener_tcp.go
+++ b/common/listener/listener_tcp.go
@@ -46,10 +46,15 @@ func (l *Listener) ListenTCP() (net.Listener, error) {
 		if keepInterval == 0 {
 			keepInterval = C.TCPKeepAliveInterval
 		}
+		keepCount := l.listenOptions.TCPKeepAliveCount
+		if keepCount < 0 {
+			keepCount = 0
+		}
 		listenConfig.KeepAliveConfig = net.KeepAliveConfig{
 			Enable:   true,
 			Idle:     keepIdle,
 			Interval: keepInterval,
+			Count:    keepCount,
 		}
 	}
 	if l.listenOptions.TCPMultiPath {

--- a/docs/configuration/shared/dial.md
+++ b/docs/configuration/shared/dial.md
@@ -40,6 +40,7 @@ icon: material/new-box
   "disable_tcp_keep_alive": false,
   "tcp_keep_alive": "",
   "tcp_keep_alive_interval": "",
+  "tcp_keep_alive_count": 0,
   "udp_fragment": false,
 
   "domain_resolver": "", // or {}
@@ -158,6 +159,12 @@ TCP keep alive initial period.
 TCP keep alive interval.
 
 `75s` will be used by default.
+
+#### tcp_keep_alive_count
+
+TCP keep alive probe count.
+
+The system default will be used by default.
 
 #### udp_fragment
 

--- a/docs/configuration/shared/dial.zh.md
+++ b/docs/configuration/shared/dial.zh.md
@@ -40,6 +40,7 @@ icon: material/new-box
   "disable_tcp_keep_alive": false,
   "tcp_keep_alive": "",
   "tcp_keep_alive_interval": "",
+  "tcp_keep_alive_count": 0,
   "udp_fragment": false,
 
   "domain_resolver": "", // 或 {}
@@ -156,6 +157,12 @@ TCP keep alive 初始周期。
 TCP keep alive 间隔。
 
 默认使用 `75s`。
+
+#### tcp_keep_alive_count
+
+TCP keep alive 探测次数。
+
+默认使用系统默认值。
 
 #### udp_fragment
 

--- a/docs/configuration/shared/listen.md
+++ b/docs/configuration/shared/listen.md
@@ -37,6 +37,7 @@ icon: material/new-box
   "disable_tcp_keep_alive": false,
   "tcp_keep_alive": "",
   "tcp_keep_alive_interval": "",
+  "tcp_keep_alive_count": 0,
   "udp_fragment": false,
   "udp_timeout": "",
   "detour": "",
@@ -130,6 +131,12 @@ TCP keep alive initial period.
 TCP keep alive interval.
 
 `75s` will be used by default.
+
+#### tcp_keep_alive_count
+
+TCP keep alive probe count.
+
+The system default will be used by default.
 
 #### udp_fragment
 

--- a/docs/configuration/shared/listen.zh.md
+++ b/docs/configuration/shared/listen.zh.md
@@ -37,6 +37,7 @@ icon: material/new-box
   "disable_tcp_keep_alive": false,
   "tcp_keep_alive": "",
   "tcp_keep_alive_interval": "",
+  "tcp_keep_alive_count": 0,
   "udp_fragment": false,
   "udp_timeout": "",
   "detour": "",
@@ -130,6 +131,12 @@ TCP keep alive 初始周期。
 TCP keep alive 间隔。
 
 默认使用 `75s`。
+
+#### tcp_keep_alive_count
+
+TCP keep alive 探测次数。
+
+默认使用系统默认值。
 
 #### udp_fragment
 

--- a/option/inbound.go
+++ b/option/inbound.go
@@ -67,6 +67,7 @@ type ListenOptions struct {
 	DisableTCPKeepAlive  bool               `json:"disable_tcp_keep_alive,omitempty"`
 	TCPKeepAlive         badoption.Duration `json:"tcp_keep_alive,omitempty"`
 	TCPKeepAliveInterval badoption.Duration `json:"tcp_keep_alive_interval,omitempty"`
+	TCPKeepAliveCount    int               `json:"tcp_keep_alive_count,omitempty"`
 	TCPFastOpen          bool               `json:"tcp_fast_open,omitempty"`
 	TCPMultiPath         bool               `json:"tcp_multi_path,omitempty"`
 	UDPFragment          *bool              `json:"udp_fragment,omitempty"`

--- a/option/outbound.go
+++ b/option/outbound.go
@@ -80,6 +80,7 @@ type DialerOptions struct {
 	DisableTCPKeepAlive  bool                              `json:"disable_tcp_keep_alive,omitempty"`
 	TCPKeepAlive         badoption.Duration                `json:"tcp_keep_alive,omitempty"`
 	TCPKeepAliveInterval badoption.Duration                `json:"tcp_keep_alive_interval,omitempty"`
+	TCPKeepAliveCount    int                               `json:"tcp_keep_alive_count,omitempty"`
 	UDPFragment          *bool                             `json:"udp_fragment,omitempty"`
 	UDPFragmentDefault   bool                              `json:"-"`
 	DomainResolver       *DomainResolveOptions             `json:"domain_resolver,omitempty"`


### PR DESCRIPTION
Closes #3824

Add `tcp_keep_alive_count` option to configure TCP_KEEPCNT for both inbound (ListenOptions) and outbound (DialerOptions).

After the keepalive refactoring in dev-next (switching to `net.KeepAliveConfig` and removing `control.SetKeepAlivePeriod`), the only remaining missing piece from #3824 is the ability to configure the probe count.

Changes:
- Add `TCPKeepAliveCount` field to `ListenOptions` and `DialerOptions`
- Set `Count` in `net.KeepAliveConfig` for both dialer and listener
- Negative values are clamped to 0 (use system default)
- Default value is 0 (system default, no behavior change for existing users)
- Add documentation for the new option (en/zh)