### PR TITLE
Fix HTTP transport server

### DIFF
--- a/transport/v2rayhttp/server.go
+++ b/transport/v2rayhttp/server.go
@@ -136,10 +136,12 @@ func (s *Server) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		s.handler.NewConnectionEx(DupContext(request.Context()), conn, source, M.Socksaddr{}, nil)
 	} else {
 		writer.WriteHeader(http.StatusOK)
+		flusher := writer.(http.Flusher)
+		flusher.Flush()
 		done := make(chan struct{})
 		conn := NewHTTP2Wrapper(&ServerHTTPConn{
 			NewHTTPConn(request.Body, writer),
-			writer.(http.Flusher),
+			flusher,
 		})
 		s.handler.NewConnectionEx(request.Context(), conn, source, M.Socksaddr{}, N.OnceClose(func(it error) {
 			close(done)


### PR DESCRIPTION
sing-box HTTP transport server is currently incompatible with V2Ray HTTP transport client.

Reference: https://github.com/v2fly/v2ray-core/blob/9cf6a45519995778b8b50a63cf0b263e35b70419/transport/internet/http/hub.go#L75-L78