### PR TITLE
Fix DNS exchange failure with gRPC detour

### DIFF
--- a/dns/transport/connector.go
+++ b/dns/transport/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"time"
 )
 
 type ConnectorCallbacks[T any] struct {
@@ -16,10 +17,11 @@ type Connector[T any] struct {
 	dial      func(ctx context.Context) (T, error)
 	callbacks ConnectorCallbacks[T]
 
-	access        sync.Mutex
-	connection    T
-	hasConnection bool
-	connecting    chan struct{}
+	access           sync.Mutex
+	connection       T
+	hasConnection    bool
+	connectionCancel context.CancelFunc
+	connecting       chan struct{}
 
 	closeCtx context.Context
 	closed   bool
@@ -47,8 +49,15 @@ func NewSingleflightConnector(closeCtx context.Context, dial func(context.Contex
 	})
 }
 
+type contextKeyConnecting struct{}
+
 func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 	var zero T
+	if ctx.Value(contextKeyConnecting{}) != nil {
+		connection, _, err := c.dialWithCancellation(ctx)
+		return connection, err
+	}
+	ctx = context.WithValue(ctx, contextKeyConnecting{}, true)
 	for {
 		c.access.Lock()
 
@@ -64,6 +73,10 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 		}
 
 		c.hasConnection = false
+		if c.connectionCancel != nil {
+			c.connectionCancel()
+			c.connectionCancel = nil
+		}
 
 		if c.connecting != nil {
 			connecting := c.connecting
@@ -82,7 +95,7 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 		c.connecting = make(chan struct{})
 		c.access.Unlock()
 
-		connection, err := c.dialWithCancellation(ctx)
+		connection, cancel, err := c.dialWithCancellation(ctx)
 
 		c.access.Lock()
 		close(c.connecting)
@@ -94,6 +107,7 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 		}
 
 		if c.closed {
+			cancel()
 			c.callbacks.Close(connection)
 			c.access.Unlock()
 			return zero, ErrTransportClosed
@@ -101,6 +115,7 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 
 		c.connection = connection
 		c.hasConnection = true
+		c.connectionCancel = cancel
 		result := c.connection
 		c.access.Unlock()
 
@@ -108,19 +123,39 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 	}
 }
 
-func (c *Connector[T]) dialWithCancellation(ctx context.Context) (T, error) {
-	dialCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+func (c *Connector[T]) dialWithCancellation(ctx context.Context) (T, context.CancelFunc, error) {
+	var zero T
+	connCtx, cancel := context.WithCancel(c.closeCtx)
 
+	dialDone := make(chan struct{})
 	go func() {
 		select {
-		case <-c.closeCtx.Done():
+		case <-ctx.Done():
 			cancel()
-		case <-dialCtx.Done():
+		case <-dialDone:
 		}
 	}()
 
-	return c.dial(dialCtx)
+	connection, err := c.dial(valueContext{connCtx, ctx})
+	close(dialDone)
+	if err != nil {
+		cancel()
+		return zero, nil, err
+	}
+	return connection, cancel, nil
+}
+
+type valueContext struct {
+	context.Context
+	parent context.Context
+}
+
+func (v valueContext) Value(key any) any {
+	return v.parent.Value(key)
+}
+
+func (v valueContext) Deadline() (time.Time, bool) {
+	return v.parent.Deadline()
 }
 
 func (c *Connector[T]) Close() error {
@@ -132,6 +167,10 @@ func (c *Connector[T]) Close() error {
 	}
 	c.closed = true
 
+	if c.connectionCancel != nil {
+		c.connectionCancel()
+		c.connectionCancel = nil
+	}
 	if c.hasConnection {
 		c.callbacks.Close(c.connection)
 		c.hasConnection = false
@@ -144,6 +183,10 @@ func (c *Connector[T]) Reset() {
 	c.access.Lock()
 	defer c.access.Unlock()
 
+	if c.connectionCancel != nil {
+		c.connectionCancel()
+		c.connectionCancel = nil
+	}
 	if c.hasConnection {
 		c.callbacks.Reset(c.connection)
 		c.hasConnection = false

--- a/transport/v2raygrpc/client.go
+++ b/transport/v2raygrpc/client.go
@@ -106,7 +106,7 @@ func (c *Client) DialContext(ctx context.Context) (net.Conn, error) {
 		cancel(err)
 		return nil, err
 	}
-	return NewGRPCConn(stream), nil
+	return NewGRPCConn(stream, cancel), nil
 }
 
 func (c *Client) Close() error {

--- a/transport/v2raygrpc/conn.go
+++ b/transport/v2raygrpc/conn.go
@@ -1,6 +1,7 @@
 package v2raygrpc
 
 import (
+	"context"
 	"net"
 	"os"
 	"time"
@@ -14,16 +15,18 @@ var _ net.Conn = (*GRPCConn)(nil)
 
 type GRPCConn struct {
 	GunService
-	cache []byte
+	cache  []byte
+	cancel context.CancelCauseFunc
 }
 
-func NewGRPCConn(service GunService) *GRPCConn {
+func NewGRPCConn(service GunService, cancel context.CancelCauseFunc) *GRPCConn {
 	//nolint:staticcheck
 	if client, isClient := service.(GunService_TunClient); isClient {
 		service = &clientConnWrapper{client}
 	}
 	return &GRPCConn{
 		GunService: service,
+		cancel:     cancel,
 	}
 }
 
@@ -54,6 +57,9 @@ func (c *GRPCConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *GRPCConn) Close() error {
+	if c.cancel != nil {
+		c.cancel(nil)
+	}
 	return nil
 }
 

--- a/transport/v2raygrpc/server.go
+++ b/transport/v2raygrpc/server.go
@@ -52,7 +52,7 @@ func NewServer(ctx context.Context, logger logger.ContextLogger, options option.
 }
 
 func (s *Server) Tun(server GunService_TunServer) error {
-	conn := NewGRPCConn(server)
+	conn := NewGRPCConn(server, nil)
 	var source M.Socksaddr
 	if remotePeer, loaded := peer.FromContext(server.Context()); loaded {
 		source = M.SocksaddrFromNet(remotePeer.Addr)


### PR DESCRIPTION
This fix resolves a regression introduced in v1.13 where DNS queries fail with "io: read/write on closed pipe" when routed through a gRPC-based outbound (e.g., VLESS + gRPC + Reality).

The issue stemmed from the dns.Connector's lifecycle management: it previously cancelled the dial context immediately after a successful dial. While this is fine for standard TCP/UDP, gRPC streams are intrinsically bound to their context; cancelling it terminates the stream prematurely.

Fix:
- dns: Modified Connector to use a long-lived base context for the connection, while still respecting the caller's timeout during dial.
- transport/v2raygrpc: Implemented explicit stream cancellation in `GRPCConn.Close` to ensure resources are released correctly when the connector decides to close or reset the connection.