### PR TITLE
Fix DNS exchange failure and recursion deadlock in connector

### DIFF
--- a/adapter/inbound.go
+++ b/adapter/inbound.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"time"
 
@@ -82,6 +83,8 @@ type InboundContext struct {
 	SourceGeoIPCode      string
 	GeoIPCode            string
 	ProcessInfo          *ConnectionOwner
+	SourceMACAddress     net.HardwareAddr
+	SourceHostname       string
 	QueryType            uint16
 	FakeIP               bool
 

--- a/adapter/neighbor.go
+++ b/adapter/neighbor.go
@@ -5,9 +5,19 @@ import (
 	"net/netip"
 )
 
+type NeighborEntry struct {
+	Address    netip.Addr
+	MACAddress net.HardwareAddr
+	Hostname   string
+}
+
 type NeighborResolver interface {
 	LookupMAC(address netip.Addr) (net.HardwareAddr, bool)
 	LookupHostname(address netip.Addr) (string, bool)
 	Start() error
 	Close() error
+}
+
+type NeighborUpdateListener interface {
+	UpdateNeighborTable(entries []NeighborEntry)
 }

--- a/adapter/neighbor.go
+++ b/adapter/neighbor.go
@@ -1,0 +1,13 @@
+package adapter
+
+import (
+	"net"
+	"net/netip"
+)
+
+type NeighborResolver interface {
+	LookupMAC(address netip.Addr) (net.HardwareAddr, bool)
+	LookupHostname(address netip.Addr) (string, bool)
+	Start() error
+	Close() error
+}

--- a/adapter/platform.go
+++ b/adapter/platform.go
@@ -36,6 +36,10 @@ type PlatformInterface interface {
 
 	UsePlatformNotification() bool
 	SendNotification(notification *Notification) error
+
+	UsePlatformNeighborResolver() bool
+	StartNeighborMonitor(listener NeighborUpdateListener) error
+	CloseNeighborMonitor(listener NeighborUpdateListener) error
 }
 
 type FindConnectionOwnerRequest struct {

--- a/adapter/router.go
+++ b/adapter/router.go
@@ -26,6 +26,8 @@ type Router interface {
 	RuleSet(tag string) (RuleSet, bool)
 	Rules() []Rule
 	NeedFindProcess() bool
+	NeedFindNeighbor() bool
+	NeighborResolver() NeighborResolver
 	AppendTracker(tracker ConnectionTracker)
 	ResetNetwork()
 }

--- a/dns/transport/connector.go
+++ b/dns/transport/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"time"
 )
 
 type ConnectorCallbacks[T any] struct {
@@ -16,10 +17,11 @@ type Connector[T any] struct {
 	dial      func(ctx context.Context) (T, error)
 	callbacks ConnectorCallbacks[T]
 
-	access        sync.Mutex
-	connection    T
-	hasConnection bool
-	connecting    chan struct{}
+	access           sync.Mutex
+	connection       T
+	hasConnection    bool
+	connectionCancel context.CancelFunc
+	connecting       chan struct{}
 
 	closeCtx context.Context
 	closed   bool
@@ -47,8 +49,15 @@ func NewSingleflightConnector(closeCtx context.Context, dial func(context.Contex
 	})
 }
 
+type contextKeyConnecting struct{}
+
 func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 	var zero T
+	if ctx.Value(contextKeyConnecting{}) != nil {
+		connection, _, err := c.dialWithCancellation(ctx)
+		return connection, err
+	}
+	ctx = context.WithValue(ctx, contextKeyConnecting{}, true)
 	for {
 		c.access.Lock()
 
@@ -64,6 +73,10 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 		}
 
 		c.hasConnection = false
+		if c.connectionCancel != nil {
+			c.connectionCancel()
+			c.connectionCancel = nil
+		}
 
 		if c.connecting != nil {
 			connecting := c.connecting
@@ -82,7 +95,7 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 		c.connecting = make(chan struct{})
 		c.access.Unlock()
 
-		connection, err := c.dialWithCancellation(ctx)
+		connection, cancel, err := c.dialWithCancellation(ctx)
 
 		c.access.Lock()
 		close(c.connecting)
@@ -94,6 +107,7 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 		}
 
 		if c.closed {
+			cancel()
 			c.callbacks.Close(connection)
 			c.access.Unlock()
 			return zero, ErrTransportClosed
@@ -101,6 +115,7 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 
 		c.connection = connection
 		c.hasConnection = true
+		c.connectionCancel = cancel
 		result := c.connection
 		c.access.Unlock()
 
@@ -108,19 +123,39 @@ func (c *Connector[T]) Get(ctx context.Context) (T, error) {
 	}
 }
 
-func (c *Connector[T]) dialWithCancellation(ctx context.Context) (T, error) {
-	dialCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+func (c *Connector[T]) dialWithCancellation(ctx context.Context) (T, context.CancelFunc, error) {
+	var zero T
+	connCtx, cancel := context.WithCancel(c.closeCtx)
 
+	dialDone := make(chan struct{})
 	go func() {
 		select {
-		case <-c.closeCtx.Done():
+		case <-ctx.Done():
 			cancel()
-		case <-dialCtx.Done():
+		case <-dialDone:
 		}
 	}()
 
-	return c.dial(dialCtx)
+	connection, err := c.dial(valueContext{connCtx, ctx})
+	close(dialDone)
+	if err != nil {
+		cancel()
+		return zero, nil, err
+	}
+	return connection, cancel, nil
+}
+
+type valueContext struct {
+	context.Context
+	parent context.Context
+}
+
+func (v valueContext) Value(key any) any {
+	return v.parent.Value(key)
+}
+
+func (v valueContext) Deadline() (time.Time, bool) {
+	return v.parent.Deadline()
 }
 
 func (c *Connector[T]) Close() error {
@@ -132,6 +167,10 @@ func (c *Connector[T]) Close() error {
 	}
 	c.closed = true
 
+	if c.connectionCancel != nil {
+		c.connectionCancel()
+		c.connectionCancel = nil
+	}
 	if c.hasConnection {
 		c.callbacks.Close(c.connection)
 		c.hasConnection = false
@@ -144,6 +183,10 @@ func (c *Connector[T]) Reset() {
 	c.access.Lock()
 	defer c.access.Unlock()
 
+	if c.connectionCancel != nil {
+		c.connectionCancel()
+		c.connectionCancel = nil
+	}
 	if c.hasConnection {
 		c.callbacks.Reset(c.connection)
 		c.hasConnection = false

--- a/docs/configuration/dns/rule.md
+++ b/docs/configuration/dns/rule.md
@@ -2,6 +2,11 @@
 icon: material/alert-decagram
 ---
 
+!!! quote "Changes in sing-box 1.14.0"
+
+    :material-plus: [source_mac_address](#source_mac_address)  
+    :material-plus: [source_hostname](#source_hostname)
+
 !!! quote "Changes in sing-box 1.13.0"
 
     :material-plus: [interface_address](#interface_address)  
@@ -148,6 +153,12 @@ icon: material/alert-decagram
         },
         "default_interface_address": [
           "2000::/3"
+        ],
+        "source_mac_address": [
+          "00:11:22:33:44:55"
+        ],
+        "source_hostname": [
+          "my-device"
         ],
         "wifi_ssid": [
           "My WIFI"
@@ -407,6 +418,26 @@ Matches network interface (same values as `network_type`) address.
     Only supported on Linux, Windows, and macOS.
 
 Match default interface address.
+
+#### source_mac_address
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux with `route.find_neighbor` enabled.
+
+Match source device MAC address.
+
+#### source_hostname
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux with `route.find_neighbor` enabled.
+
+Match source device hostname from DHCP leases.
 
 #### wifi_ssid
 

--- a/docs/configuration/dns/rule.zh.md
+++ b/docs/configuration/dns/rule.zh.md
@@ -2,6 +2,11 @@
 icon: material/alert-decagram
 ---
 
+!!! quote "sing-box 1.14.0 中的更改"
+
+    :material-plus: [source_mac_address](#source_mac_address)  
+    :material-plus: [source_hostname](#source_hostname)
+
 !!! quote "sing-box 1.13.0 中的更改"
 
     :material-plus: [interface_address](#interface_address)  
@@ -148,6 +153,12 @@ icon: material/alert-decagram
         },
         "default_interface_address": [
           "2000::/3"
+        ],
+        "source_mac_address": [
+          "00:11:22:33:44:55"
+        ],
+        "source_hostname": [
+          "my-device"
         ],
         "wifi_ssid": [
           "My WIFI"
@@ -406,6 +417,26 @@ Available values: `wifi`, `cellular`, `ethernet` and `other`.
     仅支持 Linux、Windows 和 macOS.
 
 匹配默认接口地址。
+
+#### source_mac_address
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux，且需要 `route.find_neighbor` 已启用。
+
+匹配源设备 MAC 地址。
+
+#### source_hostname
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux，且需要 `route.find_neighbor` 已启用。
+
+匹配源设备从 DHCP 租约获取的主机名。
 
 #### wifi_ssid
 

--- a/docs/configuration/inbound/tun.md
+++ b/docs/configuration/inbound/tun.md
@@ -2,6 +2,11 @@
 icon: material/new-box
 ---
 
+!!! quote "Changes in sing-box 1.14.0"
+
+    :material-plus: [include_mac_address](#include_mac_address)  
+    :material-plus: [exclude_mac_address](#exclude_mac_address)
+
 !!! quote "Changes in sing-box 1.13.0"
 
     :material-plus: [auto_redirect_reset_mark](#auto_redirect_reset_mark)  
@@ -124,6 +129,12 @@ icon: material/new-box
   ],
   "exclude_package": [
     "com.android.captiveportallogin"
+  ],
+  "include_mac_address": [
+    "00:11:22:33:44:55"
+  ],
+  "exclude_mac_address": [
+    "66:77:88:99:aa:bb"
   ],
   "platform": {
     "http_proxy": {
@@ -547,6 +558,30 @@ Limit android packages in route.
 #### exclude_package
 
 Exclude android packages in route.
+
+#### include_mac_address
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux with `auto_route` and `auto_redirect` enabled.
+
+Limit MAC addresses in route. Not limited by default.
+
+Conflict with `exclude_mac_address`.
+
+#### exclude_mac_address
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux with `auto_route` and `auto_redirect` enabled.
+
+Exclude MAC addresses in route.
+
+Conflict with `include_mac_address`.
 
 #### platform
 

--- a/docs/configuration/inbound/tun.zh.md
+++ b/docs/configuration/inbound/tun.zh.md
@@ -2,6 +2,11 @@
 icon: material/new-box
 ---
 
+!!! quote "sing-box 1.14.0 中的更改"
+
+    :material-plus: [include_mac_address](#include_mac_address)  
+    :material-plus: [exclude_mac_address](#exclude_mac_address)
+
 !!! quote "sing-box 1.13.0 中的更改"
 
     :material-plus: [auto_redirect_reset_mark](#auto_redirect_reset_mark)  
@@ -125,6 +130,12 @@ icon: material/new-box
   ],
   "exclude_package": [
     "com.android.captiveportallogin"
+  ],
+  "include_mac_address": [
+    "00:11:22:33:44:55"
+  ],
+  "exclude_mac_address": [
+    "66:77:88:99:aa:bb"
   ],
   "platform": {
     "http_proxy": {
@@ -535,6 +546,30 @@ TCP/IP 栈。
 #### exclude_package
 
 排除路由的 Android 应用包名。
+
+#### include_mac_address
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux，且需要 `auto_route` 和 `auto_redirect` 已启用。
+
+限制被路由的 MAC 地址。默认不限制。
+
+与 `exclude_mac_address` 冲突。
+
+#### exclude_mac_address
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux，且需要 `auto_route` 和 `auto_redirect` 已启用。
+
+排除路由的 MAC 地址。
+
+与 `include_mac_address` 冲突。
 
 #### platform
 

--- a/docs/configuration/route/index.md
+++ b/docs/configuration/route/index.md
@@ -4,6 +4,11 @@ icon: material/alert-decagram
 
 # Route
 
+!!! quote "Changes in sing-box 1.14.0"
+
+    :material-plus: [find_neighbor](#find_neighbor)  
+    :material-plus: [dhcp_lease_files](#dhcp_lease_files)
+
 !!! quote "Changes in sing-box 1.12.0"
 
     :material-plus: [default_domain_resolver](#default_domain_resolver)  
@@ -35,6 +40,8 @@ icon: material/alert-decagram
     "override_android_vpn": false,
     "default_interface": "",
     "default_mark": 0,
+    "find_neighbor": false,
+    "dhcp_lease_files": [],
     "default_domain_resolver": "", // or {}
     "default_network_strategy": "",
     "default_network_type": [],
@@ -106,6 +113,30 @@ Takes no effect if `auto_detect_interface` is set.
 Set routing mark by default.
 
 Takes no effect if `outbound.routing_mark` is set.
+
+#### find_neighbor
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux.
+
+Enable neighbor resolution for source MAC address and hostname lookup.
+
+Required for `source_mac_address` and `source_hostname` rule items.
+
+#### dhcp_lease_files
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux.
+
+Custom DHCP lease file paths for hostname and MAC address resolution.
+
+Automatically detected from common DHCP servers (dnsmasq, odhcpd, ISC dhcpd, Kea) if empty.
 
 #### default_domain_resolver
 

--- a/docs/configuration/route/index.zh.md
+++ b/docs/configuration/route/index.zh.md
@@ -4,6 +4,11 @@ icon: material/alert-decagram
 
 # 路由
 
+!!! quote "sing-box 1.14.0 中的更改"
+
+    :material-plus: [find_neighbor](#find_neighbor)  
+    :material-plus: [dhcp_lease_files](#dhcp_lease_files)
+
 !!! quote "sing-box 1.12.0 中的更改"
 
     :material-plus: [default_domain_resolver](#default_domain_resolver)  
@@ -37,6 +42,8 @@ icon: material/alert-decagram
     "override_android_vpn": false,
     "default_interface": "",
     "default_mark": 0,
+    "find_neighbor": false,
+    "dhcp_lease_files": [],
     "default_network_strategy": "",
     "default_fallback_delay": ""
   }
@@ -105,6 +112,30 @@ icon: material/alert-decagram
 默认为出站连接设置路由标记。
 
 如果设置了 `outbound.routing_mark` 设置，则不生效。
+
+#### find_neighbor
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux。
+
+启用邻居解析以查找源 MAC 地址和主机名。
+
+`source_mac_address` 和 `source_hostname` 规则项需要此选项。
+
+#### dhcp_lease_files
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux。
+
+用于主机名和 MAC 地址解析的自定义 DHCP 租约文件路径。
+
+为空时自动从常见 DHCP 服务器（dnsmasq、odhcpd、ISC dhcpd、Kea）检测。
 
 #### default_domain_resolver
 

--- a/docs/configuration/route/rule.md
+++ b/docs/configuration/route/rule.md
@@ -2,6 +2,11 @@
 icon: material/new-box
 ---
 
+!!! quote "Changes in sing-box 1.14.0"
+
+    :material-plus: [source_mac_address](#source_mac_address)  
+    :material-plus: [source_hostname](#source_hostname)
+
 !!! quote "Changes in sing-box 1.13.0"
 
     :material-plus: [interface_address](#interface_address)  
@@ -158,6 +163,12 @@ icon: material/new-box
         "preferred_by": [
           "tailscale",
           "wireguard"
+        ],
+        "source_mac_address": [
+          "00:11:22:33:44:55"
+        ],
+        "source_hostname": [
+          "my-device"
         ],
         "rule_set": [
           "geoip-cn",
@@ -448,6 +459,26 @@ Match specified outbounds' preferred routes.
 |-------------|-----------------------------------------------|
 | `tailscale` | Match MagicDNS domains and peers' allowed IPs |
 | `wireguard` | Match peers's allowed IPs                     |
+
+#### source_mac_address
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux with `route.find_neighbor` enabled.
+
+Match source device MAC address.
+
+#### source_hostname
+
+!!! question "Since sing-box 1.14.0"
+
+!!! quote ""
+
+    Only supported on Linux with `route.find_neighbor` enabled.
+
+Match source device hostname from DHCP leases.
 
 #### rule_set
 

--- a/docs/configuration/route/rule.zh.md
+++ b/docs/configuration/route/rule.zh.md
@@ -2,6 +2,11 @@
 icon: material/new-box
 ---
 
+!!! quote "sing-box 1.14.0 中的更改"
+
+    :material-plus: [source_mac_address](#source_mac_address)  
+    :material-plus: [source_hostname](#source_hostname)
+
 !!! quote "sing-box 1.13.0 中的更改"
 
     :material-plus: [interface_address](#interface_address)  
@@ -155,6 +160,12 @@ icon: material/new-box
         "preferred_by": [
           "tailscale",
           "wireguard"
+        ],
+        "source_mac_address": [
+          "00:11:22:33:44:55"
+        ],
+        "source_hostname": [
+          "my-device"
         ],
         "rule_set": [
           "geoip-cn",
@@ -445,6 +456,26 @@ icon: material/new-box
 |-------------|--------------------------------|
 | `tailscale` | 匹配 MagicDNS 域名和对端的 allowed IPs |
 | `wireguard` | 匹配对端的 allowed IPs              |
+
+#### source_mac_address
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux，且需要 `route.find_neighbor` 已启用。
+
+匹配源设备 MAC 地址。
+
+#### source_hostname
+
+!!! question "自 sing-box 1.14.0 起"
+
+!!! quote ""
+
+    仅支持 Linux，且需要 `route.find_neighbor` 已启用。
+
+匹配源设备从 DHCP 租约获取的主机名。
 
 #### rule_set
 

--- a/experimental/libbox/config.go
+++ b/experimental/libbox/config.go
@@ -144,6 +144,18 @@ func (s *platformInterfaceStub) SendNotification(notification *adapter.Notificat
 	return nil
 }
 
+func (s *platformInterfaceStub) UsePlatformNeighborResolver() bool {
+	return false
+}
+
+func (s *platformInterfaceStub) StartNeighborMonitor(listener adapter.NeighborUpdateListener) error {
+	return os.ErrInvalid
+}
+
+func (s *platformInterfaceStub) CloseNeighborMonitor(listener adapter.NeighborUpdateListener) error {
+	return nil
+}
+
 func (s *platformInterfaceStub) UsePlatformLocalDNSTransport() bool {
 	return false
 }

--- a/experimental/libbox/neighbor.go
+++ b/experimental/libbox/neighbor.go
@@ -1,23 +1,13 @@
-//go:build linux
-
 package libbox
 
 import (
 	"net"
 	"net/netip"
-	"slices"
-	"time"
-
-	"github.com/sagernet/sing-box/route"
-	E "github.com/sagernet/sing/common/exceptions"
-
-	"github.com/mdlayher/netlink"
-	"golang.org/x/sys/unix"
 )
 
 type NeighborEntry struct {
 	Address    string
-	MACAddress string
+	MacAddress string
 	Hostname   string
 }
 
@@ -30,80 +20,8 @@ type NeighborSubscription struct {
 	done chan struct{}
 }
 
-func SubscribeNeighborTable(listener NeighborUpdateListener) (*NeighborSubscription, error) {
-	entries, err := route.ReadNeighborEntries()
-	if err != nil {
-		return nil, E.Cause(err, "initial neighbor dump")
-	}
-	table := make(map[netip.Addr]net.HardwareAddr)
-	for _, entry := range entries {
-		table[entry.Address] = entry.MACAddress
-	}
-	listener.UpdateNeighborTable(tableToIterator(table))
-	connection, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
-		Groups: 1 << (unix.RTNLGRP_NEIGH - 1),
-	})
-	if err != nil {
-		return nil, E.Cause(err, "subscribe neighbor updates")
-	}
-	subscription := &NeighborSubscription{
-		done: make(chan struct{}),
-	}
-	go subscription.loop(listener, connection, table)
-	return subscription, nil
-}
-
 func (s *NeighborSubscription) Close() {
 	close(s.done)
-}
-
-func (s *NeighborSubscription) loop(listener NeighborUpdateListener, connection *netlink.Conn, table map[netip.Addr]net.HardwareAddr) {
-	defer connection.Close()
-	for {
-		select {
-		case <-s.done:
-			return
-		default:
-		}
-		err := connection.SetReadDeadline(time.Now().Add(3 * time.Second))
-		if err != nil {
-			return
-		}
-		messages, err := connection.Receive()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-				continue
-			}
-			select {
-			case <-s.done:
-				return
-			default:
-			}
-			continue
-		}
-		changed := false
-		for _, message := range messages {
-			address, mac, isDelete, ok := route.ParseNeighborMessage(message)
-			if !ok {
-				continue
-			}
-			if isDelete {
-				if _, exists := table[address]; exists {
-					delete(table, address)
-					changed = true
-				}
-			} else {
-				existing, exists := table[address]
-				if !exists || !slices.Equal(existing, mac) {
-					table[address] = mac
-					changed = true
-				}
-			}
-		}
-		if changed {
-			listener.UpdateNeighborTable(tableToIterator(table))
-		}
-	}
 }
 
 func tableToIterator(table map[netip.Addr]net.HardwareAddr) NeighborEntryIterator {
@@ -111,7 +29,7 @@ func tableToIterator(table map[netip.Addr]net.HardwareAddr) NeighborEntryIterato
 	for address, mac := range table {
 		entries = append(entries, &NeighborEntry{
 			Address:    address.String(),
-			MACAddress: mac.String(),
+			MacAddress: mac.String(),
 		})
 	}
 	return &neighborEntryIterator{entries}

--- a/experimental/libbox/neighbor.go
+++ b/experimental/libbox/neighbor.go
@@ -1,0 +1,135 @@
+//go:build linux
+
+package libbox
+
+import (
+	"net"
+	"net/netip"
+	"slices"
+	"time"
+
+	"github.com/sagernet/sing-box/route"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type NeighborEntry struct {
+	Address    string
+	MACAddress string
+	Hostname   string
+}
+
+type NeighborEntryIterator interface {
+	Next() *NeighborEntry
+	HasNext() bool
+}
+
+type NeighborSubscription struct {
+	done chan struct{}
+}
+
+func SubscribeNeighborTable(listener NeighborUpdateListener) (*NeighborSubscription, error) {
+	entries, err := route.ReadNeighborEntries()
+	if err != nil {
+		return nil, E.Cause(err, "initial neighbor dump")
+	}
+	table := make(map[netip.Addr]net.HardwareAddr)
+	for _, entry := range entries {
+		table[entry.Address] = entry.MACAddress
+	}
+	listener.UpdateNeighborTable(tableToIterator(table))
+	connection, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
+		Groups: 1 << (unix.RTNLGRP_NEIGH - 1),
+	})
+	if err != nil {
+		return nil, E.Cause(err, "subscribe neighbor updates")
+	}
+	subscription := &NeighborSubscription{
+		done: make(chan struct{}),
+	}
+	go subscription.loop(listener, connection, table)
+	return subscription, nil
+}
+
+func (s *NeighborSubscription) Close() {
+	close(s.done)
+}
+
+func (s *NeighborSubscription) loop(listener NeighborUpdateListener, connection *netlink.Conn, table map[netip.Addr]net.HardwareAddr) {
+	defer connection.Close()
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+		err := connection.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if err != nil {
+			return
+		}
+		messages, err := connection.Receive()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				continue
+			}
+			select {
+			case <-s.done:
+				return
+			default:
+			}
+			continue
+		}
+		changed := false
+		for _, message := range messages {
+			address, mac, isDelete, ok := route.ParseNeighborMessage(message)
+			if !ok {
+				continue
+			}
+			if isDelete {
+				if _, exists := table[address]; exists {
+					delete(table, address)
+					changed = true
+				}
+			} else {
+				existing, exists := table[address]
+				if !exists || !slices.Equal(existing, mac) {
+					table[address] = mac
+					changed = true
+				}
+			}
+		}
+		if changed {
+			listener.UpdateNeighborTable(tableToIterator(table))
+		}
+	}
+}
+
+func tableToIterator(table map[netip.Addr]net.HardwareAddr) NeighborEntryIterator {
+	entries := make([]*NeighborEntry, 0, len(table))
+	for address, mac := range table {
+		entries = append(entries, &NeighborEntry{
+			Address:    address.String(),
+			MACAddress: mac.String(),
+		})
+	}
+	return &neighborEntryIterator{entries}
+}
+
+type neighborEntryIterator struct {
+	entries []*NeighborEntry
+}
+
+func (i *neighborEntryIterator) HasNext() bool {
+	return len(i.entries) > 0
+}
+
+func (i *neighborEntryIterator) Next() *NeighborEntry {
+	if len(i.entries) == 0 {
+		return nil
+	}
+	entry := i.entries[0]
+	i.entries = i.entries[1:]
+	return entry
+}

--- a/experimental/libbox/neighbor_darwin.go
+++ b/experimental/libbox/neighbor_darwin.go
@@ -1,0 +1,123 @@
+//go:build darwin
+
+package libbox
+
+import (
+	"net"
+	"net/netip"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/sagernet/sing-box/route"
+	"github.com/sagernet/sing/common/buf"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	xroute "golang.org/x/net/route"
+	"golang.org/x/sys/unix"
+)
+
+func SubscribeNeighborTable(listener NeighborUpdateListener) (*NeighborSubscription, error) {
+	entries, err := route.ReadNeighborEntries()
+	if err != nil {
+		return nil, E.Cause(err, "initial neighbor dump")
+	}
+	table := make(map[netip.Addr]net.HardwareAddr)
+	for _, entry := range entries {
+		table[entry.Address] = entry.MACAddress
+	}
+	listener.UpdateNeighborTable(tableToIterator(table))
+	routeSocket, err := unix.Socket(unix.AF_ROUTE, unix.SOCK_RAW, 0)
+	if err != nil {
+		return nil, E.Cause(err, "open route socket")
+	}
+	err = unix.SetNonblock(routeSocket, true)
+	if err != nil {
+		unix.Close(routeSocket)
+		return nil, E.Cause(err, "set route socket nonblock")
+	}
+	subscription := &NeighborSubscription{
+		done: make(chan struct{}),
+	}
+	go subscription.loop(listener, routeSocket, table)
+	return subscription, nil
+}
+
+func (s *NeighborSubscription) loop(listener NeighborUpdateListener, routeSocket int, table map[netip.Addr]net.HardwareAddr) {
+	routeSocketFile := os.NewFile(uintptr(routeSocket), "route")
+	defer routeSocketFile.Close()
+	buffer := buf.NewPacket()
+	defer buffer.Release()
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+		tv := unix.NsecToTimeval(int64(3 * time.Second))
+		_ = unix.SetsockoptTimeval(routeSocket, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv)
+		n, err := routeSocketFile.Read(buffer.FreeBytes())
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				continue
+			}
+			select {
+			case <-s.done:
+				return
+			default:
+			}
+			continue
+		}
+		messages, err := xroute.ParseRIB(xroute.RIBTypeRoute, buffer.FreeBytes()[:n])
+		if err != nil {
+			continue
+		}
+		changed := false
+		for _, message := range messages {
+			routeMessage, isRouteMessage := message.(*xroute.RouteMessage)
+			if !isRouteMessage {
+				continue
+			}
+			if routeMessage.Flags&unix.RTF_LLINFO == 0 {
+				continue
+			}
+			address, mac, isDelete, ok := route.ParseRouteNeighborMessage(routeMessage)
+			if !ok {
+				continue
+			}
+			if isDelete {
+				if _, exists := table[address]; exists {
+					delete(table, address)
+					changed = true
+				}
+			} else {
+				existing, exists := table[address]
+				if !exists || !slices.Equal(existing, mac) {
+					table[address] = mac
+					changed = true
+				}
+			}
+		}
+		if changed {
+			listener.UpdateNeighborTable(tableToIterator(table))
+		}
+	}
+}
+
+func ReadBootpdLeases() NeighborEntryIterator {
+	leaseIPToMAC, ipToHostname, macToHostname := route.ReloadLeaseFiles([]string{"/var/db/dhcpd_leases"})
+	entries := make([]*NeighborEntry, 0, len(leaseIPToMAC))
+	for address, mac := range leaseIPToMAC {
+		entry := &NeighborEntry{
+			Address:    address.String(),
+			MacAddress: mac.String(),
+		}
+		hostname, found := ipToHostname[address]
+		if !found {
+			hostname = macToHostname[mac.String()]
+		}
+		entry.Hostname = hostname
+		entries = append(entries, entry)
+	}
+	return &neighborEntryIterator{entries}
+}

--- a/experimental/libbox/neighbor_linux.go
+++ b/experimental/libbox/neighbor_linux.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package libbox
+
+import (
+	"net"
+	"net/netip"
+	"slices"
+	"time"
+
+	"github.com/sagernet/sing-box/route"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func SubscribeNeighborTable(listener NeighborUpdateListener) (*NeighborSubscription, error) {
+	entries, err := route.ReadNeighborEntries()
+	if err != nil {
+		return nil, E.Cause(err, "initial neighbor dump")
+	}
+	table := make(map[netip.Addr]net.HardwareAddr)
+	for _, entry := range entries {
+		table[entry.Address] = entry.MACAddress
+	}
+	listener.UpdateNeighborTable(tableToIterator(table))
+	connection, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
+		Groups: 1 << (unix.RTNLGRP_NEIGH - 1),
+	})
+	if err != nil {
+		return nil, E.Cause(err, "subscribe neighbor updates")
+	}
+	subscription := &NeighborSubscription{
+		done: make(chan struct{}),
+	}
+	go subscription.loop(listener, connection, table)
+	return subscription, nil
+}
+
+func (s *NeighborSubscription) loop(listener NeighborUpdateListener, connection *netlink.Conn, table map[netip.Addr]net.HardwareAddr) {
+	defer connection.Close()
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+		err := connection.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if err != nil {
+			return
+		}
+		messages, err := connection.Receive()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				continue
+			}
+			select {
+			case <-s.done:
+				return
+			default:
+			}
+			continue
+		}
+		changed := false
+		for _, message := range messages {
+			address, mac, isDelete, ok := route.ParseNeighborMessage(message)
+			if !ok {
+				continue
+			}
+			if isDelete {
+				if _, exists := table[address]; exists {
+					delete(table, address)
+					changed = true
+				}
+			} else {
+				existing, exists := table[address]
+				if !exists || !slices.Equal(existing, mac) {
+					table[address] = mac
+					changed = true
+				}
+			}
+		}
+		if changed {
+			listener.UpdateNeighborTable(tableToIterator(table))
+		}
+	}
+}

--- a/experimental/libbox/neighbor_stub.go
+++ b/experimental/libbox/neighbor_stub.go
@@ -1,24 +1,9 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package libbox
 
 import "os"
 
-type NeighborEntry struct {
-	Address    string
-	MACAddress string
-	Hostname   string
-}
-
-type NeighborEntryIterator interface {
-	Next() *NeighborEntry
-	HasNext() bool
-}
-
-type NeighborSubscription struct{}
-
-func SubscribeNeighborTable(listener NeighborUpdateListener) (*NeighborSubscription, error) {
+func SubscribeNeighborTable(_ NeighborUpdateListener) (*NeighborSubscription, error) {
 	return nil, os.ErrInvalid
 }
-
-func (s *NeighborSubscription) Close() {}

--- a/experimental/libbox/neighbor_stub.go
+++ b/experimental/libbox/neighbor_stub.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+package libbox
+
+import "os"
+
+type NeighborEntry struct {
+	Address    string
+	MACAddress string
+	Hostname   string
+}
+
+type NeighborEntryIterator interface {
+	Next() *NeighborEntry
+	HasNext() bool
+}
+
+type NeighborSubscription struct{}
+
+func SubscribeNeighborTable(listener NeighborUpdateListener) (*NeighborSubscription, error) {
+	return nil, os.ErrInvalid
+}
+
+func (s *NeighborSubscription) Close() {}

--- a/experimental/libbox/platform.go
+++ b/experimental/libbox/platform.go
@@ -23,6 +23,7 @@ type PlatformInterface interface {
 	SendNotification(notification *Notification) error
 	StartNeighborMonitor(listener NeighborUpdateListener) error
 	CloseNeighborMonitor(listener NeighborUpdateListener) error
+	RegisterMyInterface(name string)
 }
 
 type NeighborUpdateListener interface {

--- a/experimental/libbox/platform.go
+++ b/experimental/libbox/platform.go
@@ -21,6 +21,12 @@ type PlatformInterface interface {
 	SystemCertificates() StringIterator
 	ClearDNSCache()
 	SendNotification(notification *Notification) error
+	StartNeighborMonitor(listener NeighborUpdateListener) error
+	CloseNeighborMonitor(listener NeighborUpdateListener) error
+}
+
+type NeighborUpdateListener interface {
+	UpdateNeighborTable(entries NeighborEntryIterator)
 }
 
 type ConnectionOwner struct {

--- a/experimental/libbox/service.go
+++ b/experimental/libbox/service.go
@@ -78,6 +78,7 @@ func (w *platformInterfaceWrapper) OpenInterface(options *tun.Options, platformO
 	}
 	options.FileDescriptor = dupFd
 	w.myTunName = options.Name
+	w.iif.RegisterMyInterface(options.Name)
 	return tun.New(*options)
 }
 
@@ -240,11 +241,14 @@ func (w *neighborUpdateListenerWrapper) UpdateNeighborTable(entries NeighborEntr
 	var result []adapter.NeighborEntry
 	for entries.HasNext() {
 		entry := entries.Next()
+		if entry == nil {
+			continue
+		}
 		address, err := netip.ParseAddr(entry.Address)
 		if err != nil {
 			continue
 		}
-		macAddress, err := net.ParseMAC(entry.MACAddress)
+		macAddress, err := net.ParseMAC(entry.MacAddress)
 		if err != nil {
 			continue
 		}

--- a/experimental/libbox/service.go
+++ b/experimental/libbox/service.go
@@ -220,6 +220,43 @@ func (w *platformInterfaceWrapper) SendNotification(notification *adapter.Notifi
 	return w.iif.SendNotification((*Notification)(notification))
 }
 
+func (w *platformInterfaceWrapper) UsePlatformNeighborResolver() bool {
+	return true
+}
+
+func (w *platformInterfaceWrapper) StartNeighborMonitor(listener adapter.NeighborUpdateListener) error {
+	return w.iif.StartNeighborMonitor(&neighborUpdateListenerWrapper{listener: listener})
+}
+
+func (w *platformInterfaceWrapper) CloseNeighborMonitor(listener adapter.NeighborUpdateListener) error {
+	return w.iif.CloseNeighborMonitor(nil)
+}
+
+type neighborUpdateListenerWrapper struct {
+	listener adapter.NeighborUpdateListener
+}
+
+func (w *neighborUpdateListenerWrapper) UpdateNeighborTable(entries NeighborEntryIterator) {
+	var result []adapter.NeighborEntry
+	for entries.HasNext() {
+		entry := entries.Next()
+		address, err := netip.ParseAddr(entry.Address)
+		if err != nil {
+			continue
+		}
+		macAddress, err := net.ParseMAC(entry.MACAddress)
+		if err != nil {
+			continue
+		}
+		result = append(result, adapter.NeighborEntry{
+			Address:    address,
+			MACAddress: macAddress,
+			Hostname:   entry.Hostname,
+		})
+	}
+	w.listener.UpdateNeighborTable(result)
+}
+
 func AvailablePort(startPort int32) (int32, error) {
 	for port := int(startPort); ; port++ {
 		if port > 65535 {

--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,13 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/insomniacslk/dhcp v0.0.0-20260220084031-5adc3eb26f91
+	github.com/jsimonetti/rtnetlink v1.4.0
 	github.com/keybase/go-keychain v0.0.1
 	github.com/libdns/acmedns v0.5.0
 	github.com/libdns/alidns v1.0.6
 	github.com/libdns/cloudflare v0.2.2
 	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/mdlayher/netlink v1.9.0
 	github.com/metacubex/utls v1.8.4
 	github.com/mholt/acmez/v3 v3.1.6
 	github.com/miekg/dns v1.1.72
@@ -39,7 +41,7 @@ require (
 	github.com/sagernet/sing-shadowsocks v0.2.8
 	github.com/sagernet/sing-shadowsocks2 v0.2.1
 	github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11
-	github.com/sagernet/sing-tun v0.8.2
+	github.com/sagernet/sing-tun v0.8.3-0.20260305131414-5083da5745ed
 	github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1
 	github.com/sagernet/smux v1.5.50-sing-box-mod.1
 	github.com/sagernet/tailscale v1.92.4-sing-box-1.13-mod.6.0.20260303140313-3bcf9a4b9349
@@ -92,11 +94,9 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/libdns/libdns v1.1.1 // indirect
-	github.com/mdlayher/netlink v1.9.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/sagernet/sing-shadowsocks2 v0.2.1 h1:dWV9OXCeFPuYGHb6IRqlSptVnSzOelnq
 github.com/sagernet/sing-shadowsocks2 v0.2.1/go.mod h1:RnXS0lExcDAovvDeniJ4IKa2IuChrdipolPYWBv9hWQ=
 github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11 h1:tK+75l64tm9WvEFrYRE1t0YxoFdWQqw/h7Uhzj0vJ+w=
 github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11/go.mod h1:sWqKnGlMipCHaGsw1sTTlimyUpgzP4WP3pjhCsYt9oA=
-github.com/sagernet/sing-tun v0.8.2 h1:rQr/x3eQCHh3oleIaoJdPdJwqzZp4+QWcJLT0Wz2xKY=
-github.com/sagernet/sing-tun v0.8.2/go.mod h1:pLCo4o+LacXEzz0bhwhJkKBjLlKOGPBNOAZ97ZVZWzs=
+github.com/sagernet/sing-tun v0.8.3-0.20260305131414-5083da5745ed h1:0XZgwnEX2HgQ/0J0The6KPEAezBz5bLl18PMTRHNN9E=
+github.com/sagernet/sing-tun v0.8.3-0.20260305131414-5083da5745ed/go.mod h1:pLCo4o+LacXEzz0bhwhJkKBjLlKOGPBNOAZ97ZVZWzs=
 github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1 h1:aSwUNYUkVyVvdmBSufR8/nRFonwJeKSIROxHcm5br9o=
 github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1/go.mod h1:P11scgTxMxVVQ8dlM27yNm3Cro40mD0+gHbnqrNGDuY=
 github.com/sagernet/smux v1.5.50-sing-box-mod.1 h1:XkJcivBC9V4wBjiGXIXZ229aZCU1hzcbp6kSkkyQ478=

--- a/option/route.go
+++ b/option/route.go
@@ -9,6 +9,8 @@ type RouteOptions struct {
 	RuleSet                    []RuleSet                         `json:"rule_set,omitempty"`
 	Final                      string                            `json:"final,omitempty"`
 	FindProcess                bool                              `json:"find_process,omitempty"`
+	FindNeighbor               bool                              `json:"find_neighbor,omitempty"`
+	DHCPLeaseFiles             badoption.Listable[string]        `json:"dhcp_lease_files,omitempty"`
 	AutoDetectInterface        bool                              `json:"auto_detect_interface,omitempty"`
 	OverrideAndroidVPN         bool                              `json:"override_android_vpn,omitempty"`
 	DefaultInterface           string                            `json:"default_interface,omitempty"`

--- a/option/rule.go
+++ b/option/rule.go
@@ -103,6 +103,8 @@ type RawDefaultRule struct {
 	InterfaceAddress         *badjson.TypedMap[string, badoption.Listable[*badoption.Prefixable]]        `json:"interface_address,omitempty"`
 	NetworkInterfaceAddress  *badjson.TypedMap[InterfaceType, badoption.Listable[*badoption.Prefixable]] `json:"network_interface_address,omitempty"`
 	DefaultInterfaceAddress  badoption.Listable[*badoption.Prefixable]                                   `json:"default_interface_address,omitempty"`
+	SourceMACAddress         badoption.Listable[string]                                                  `json:"source_mac_address,omitempty"`
+	SourceHostname           badoption.Listable[string]                                                  `json:"source_hostname,omitempty"`
 	PreferredBy              badoption.Listable[string]                                                  `json:"preferred_by,omitempty"`
 	RuleSet                  badoption.Listable[string]                                                  `json:"rule_set,omitempty"`
 	RuleSetIPCIDRMatchSource bool                                                                        `json:"rule_set_ip_cidr_match_source,omitempty"`

--- a/option/rule_dns.go
+++ b/option/rule_dns.go
@@ -106,6 +106,8 @@ type RawDefaultDNSRule struct {
 	InterfaceAddress         *badjson.TypedMap[string, badoption.Listable[*badoption.Prefixable]]        `json:"interface_address,omitempty"`
 	NetworkInterfaceAddress  *badjson.TypedMap[InterfaceType, badoption.Listable[*badoption.Prefixable]] `json:"network_interface_address,omitempty"`
 	DefaultInterfaceAddress  badoption.Listable[*badoption.Prefixable]                                   `json:"default_interface_address,omitempty"`
+	SourceMACAddress         badoption.Listable[string]                                                  `json:"source_mac_address,omitempty"`
+	SourceHostname           badoption.Listable[string]                                                  `json:"source_hostname,omitempty"`
 	RuleSet                  badoption.Listable[string]                                                  `json:"rule_set,omitempty"`
 	RuleSetIPCIDRMatchSource bool                                                                        `json:"rule_set_ip_cidr_match_source,omitempty"`
 	RuleSetIPCIDRAcceptEmpty bool                                                                        `json:"rule_set_ip_cidr_accept_empty,omitempty"`

--- a/option/tun.go
+++ b/option/tun.go
@@ -39,6 +39,8 @@ type TunInboundOptions struct {
 	IncludeAndroidUser            badoption.Listable[int]          `json:"include_android_user,omitempty"`
 	IncludePackage                badoption.Listable[string]       `json:"include_package,omitempty"`
 	ExcludePackage                badoption.Listable[string]       `json:"exclude_package,omitempty"`
+	IncludeMACAddress             badoption.Listable[string]       `json:"include_mac_address,omitempty"`
+	ExcludeMACAddress             badoption.Listable[string]       `json:"exclude_mac_address,omitempty"`
 	UDPTimeout                    UDPTimeoutCompat                 `json:"udp_timeout,omitempty"`
 	Stack                         string                           `json:"stack,omitempty"`
 	Platform                      *TunPlatformOptions              `json:"platform,omitempty"`

--- a/protocol/tun/inbound.go
+++ b/protocol/tun/inbound.go
@@ -156,6 +156,22 @@ func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLo
 	if nfQueue == 0 {
 		nfQueue = tun.DefaultAutoRedirectNFQueue
 	}
+	var includeMACAddress []net.HardwareAddr
+	for i, macString := range options.IncludeMACAddress {
+		mac, macErr := net.ParseMAC(macString)
+		if macErr != nil {
+			return nil, E.Cause(macErr, "parse include_mac_address[", i, "]")
+		}
+		includeMACAddress = append(includeMACAddress, mac)
+	}
+	var excludeMACAddress []net.HardwareAddr
+	for i, macString := range options.ExcludeMACAddress {
+		mac, macErr := net.ParseMAC(macString)
+		if macErr != nil {
+			return nil, E.Cause(macErr, "parse exclude_mac_address[", i, "]")
+		}
+		excludeMACAddress = append(excludeMACAddress, mac)
+	}
 	networkManager := service.FromContext[adapter.NetworkManager](ctx)
 	multiPendingPackets := C.IsDarwin && ((options.Stack == "gvisor" && tunMTU < 32768) || (options.Stack != "gvisor" && options.MTU <= 9000))
 	inbound := &Inbound{
@@ -193,6 +209,8 @@ func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLo
 			IncludeAndroidUser:                    options.IncludeAndroidUser,
 			IncludePackage:                        options.IncludePackage,
 			ExcludePackage:                        options.ExcludePackage,
+			IncludeMACAddress:                     includeMACAddress,
+			ExcludeMACAddress:                     excludeMACAddress,
 			InterfaceMonitor:                      networkManager.InterfaceMonitor(),
 			EXP_MultiPendingPackets:               multiPendingPackets,
 		},

--- a/route/neighbor_resolver_darwin.go
+++ b/route/neighbor_resolver_darwin.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build darwin
 
 package route
 
@@ -6,26 +6,22 @@ import (
 	"net"
 	"net/netip"
 	"os"
-	"slices"
 	"sync"
 	"time"
 
 	"github.com/sagernet/fswatch"
 	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/common/buf"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/logger"
 
-	"github.com/jsimonetti/rtnetlink"
-	"github.com/mdlayher/netlink"
+	"golang.org/x/net/route"
 	"golang.org/x/sys/unix"
 )
 
 var defaultLeaseFiles = []string{
+	"/var/db/dhcpd_leases",
 	"/tmp/dhcp.leases",
-	"/var/lib/dhcp/dhcpd.leases",
-	"/var/lib/dhcpd/dhcpd.leases",
-	"/var/lib/kea/kea-leases4.csv",
-	"/var/lib/kea/kea-leases6.csv",
 }
 
 type neighborResolver struct {
@@ -138,54 +134,46 @@ func (r *neighborResolver) LookupHostname(address netip.Addr) (string, bool) {
 }
 
 func (r *neighborResolver) loadNeighborTable() error {
-	connection, err := rtnetlink.Dial(nil)
+	entries, err := ReadNeighborEntries()
 	if err != nil {
-		return E.Cause(err, "dial rtnetlink")
-	}
-	defer connection.Close()
-	neighbors, err := connection.Neigh.List()
-	if err != nil {
-		return E.Cause(err, "list neighbors")
+		return err
 	}
 	r.access.Lock()
 	defer r.access.Unlock()
-	for _, neigh := range neighbors {
-		if neigh.Attributes == nil {
-			continue
-		}
-		if neigh.Attributes.LLAddress == nil || len(neigh.Attributes.Address) == 0 {
-			continue
-		}
-		address, ok := netip.AddrFromSlice(neigh.Attributes.Address)
-		if !ok {
-			continue
-		}
-		r.neighborIPToMAC[address] = slices.Clone(neigh.Attributes.LLAddress)
+	for _, entry := range entries {
+		r.neighborIPToMAC[entry.Address] = entry.MACAddress
 	}
 	return nil
 }
 
 func (r *neighborResolver) subscribeNeighborUpdates() {
-	connection, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
-		Groups: 1 << (unix.RTNLGRP_NEIGH - 1),
-	})
+	routeSocket, err := unix.Socket(unix.AF_ROUTE, unix.SOCK_RAW, 0)
 	if err != nil {
 		r.logger.Warn(E.Cause(err, "subscribe neighbor updates"))
 		return
 	}
-	defer connection.Close()
+	err = unix.SetNonblock(routeSocket, true)
+	if err != nil {
+		unix.Close(routeSocket)
+		r.logger.Warn(E.Cause(err, "set route socket nonblock"))
+		return
+	}
+	routeSocketFile := os.NewFile(uintptr(routeSocket), "route")
+	defer routeSocketFile.Close()
+	buffer := buf.NewPacket()
+	defer buffer.Release()
 	for {
 		select {
 		case <-r.done:
 			return
 		default:
 		}
-		err = connection.SetReadDeadline(time.Now().Add(3 * time.Second))
+		err = setReadDeadline(routeSocketFile, 3*time.Second)
 		if err != nil {
-			r.logger.Warn(E.Cause(err, "set netlink read deadline"))
+			r.logger.Warn(E.Cause(err, "set route socket read deadline"))
 			return
 		}
-		messages, err := connection.Receive()
+		n, err := routeSocketFile.Read(buffer.FreeBytes())
 		if err != nil {
 			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 				continue
@@ -198,8 +186,19 @@ func (r *neighborResolver) subscribeNeighborUpdates() {
 			r.logger.Warn(E.Cause(err, "receive neighbor update"))
 			continue
 		}
+		messages, err := route.ParseRIB(route.RIBTypeRoute, buffer.FreeBytes()[:n])
+		if err != nil {
+			continue
+		}
 		for _, message := range messages {
-			address, mac, isDelete, ok := ParseNeighborMessage(message)
+			routeMessage, isRouteMessage := message.(*route.RouteMessage)
+			if !isRouteMessage {
+				continue
+			}
+			if routeMessage.Flags&unix.RTF_LLINFO == 0 {
+				continue
+			}
+			address, mac, isDelete, ok := ParseRouteNeighborMessage(routeMessage)
 			if !ok {
 				continue
 			}
@@ -221,4 +220,20 @@ func (r *neighborResolver) doReloadLeaseFiles() {
 	r.ipToHostname = ipToHostname
 	r.macToHostname = macToHostname
 	r.access.Unlock()
+}
+
+func setReadDeadline(file *os.File, timeout time.Duration) error {
+	rawConn, err := file.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var controlErr error
+	err = rawConn.Control(func(fd uintptr) {
+		tv := unix.NsecToTimeval(int64(timeout))
+		controlErr = unix.SetsockoptTimeval(int(fd), unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv)
+	})
+	if err != nil {
+		return err
+	}
+	return controlErr
 }

--- a/route/neighbor_resolver_lease.go
+++ b/route/neighbor_resolver_lease.go
@@ -1,0 +1,386 @@
+package route
+
+import (
+	"bufio"
+	"encoding/hex"
+	"net"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func parseLeaseFile(path string, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	if strings.HasSuffix(path, "dhcpd_leases") {
+		parseBootpdLeases(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	if strings.HasSuffix(path, "kea-leases4.csv") {
+		parseKeaCSV4(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	if strings.HasSuffix(path, "kea-leases6.csv") {
+		parseKeaCSV6(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	if strings.HasSuffix(path, "dhcpd.leases") {
+		parseISCDhcpd(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	parseDnsmasqOdhcpd(file, ipToMAC, ipToHostname, macToHostname)
+}
+
+func ReloadLeaseFiles(leaseFiles []string) (leaseIPToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	leaseIPToMAC = make(map[netip.Addr]net.HardwareAddr)
+	ipToHostname = make(map[netip.Addr]string)
+	macToHostname = make(map[string]string)
+	for _, path := range leaseFiles {
+		parseLeaseFile(path, leaseIPToMAC, ipToHostname, macToHostname)
+	}
+	return
+}
+
+func parseDnsmasqOdhcpd(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	now := time.Now().Unix()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "duid ") {
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			parseOdhcpdLine(line[2:], ipToMAC, ipToHostname, macToHostname)
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		expiry, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		if expiry != 0 && expiry < now {
+			continue
+		}
+		if strings.Contains(fields[1], ":") {
+			mac, macErr := net.ParseMAC(fields[1])
+			if macErr != nil {
+				continue
+			}
+			address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[2]))
+			if !addrOK {
+				continue
+			}
+			address = address.Unmap()
+			ipToMAC[address] = mac
+			hostname := fields[3]
+			if hostname != "*" {
+				ipToHostname[address] = hostname
+				macToHostname[mac.String()] = hostname
+			}
+		} else {
+			var mac net.HardwareAddr
+			if len(fields) >= 5 {
+				duid, duidErr := parseDUID(fields[4])
+				if duidErr == nil {
+					mac, _ = extractMACFromDUID(duid)
+				}
+			}
+			address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[2]))
+			if !addrOK {
+				continue
+			}
+			address = address.Unmap()
+			if mac != nil {
+				ipToMAC[address] = mac
+			}
+			hostname := fields[3]
+			if hostname != "*" {
+				ipToHostname[address] = hostname
+				if mac != nil {
+					macToHostname[mac.String()] = hostname
+				}
+			}
+		}
+	}
+}
+
+func parseOdhcpdLine(line string, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return
+	}
+	validTime, err := strconv.ParseInt(fields[4], 10, 64)
+	if err != nil {
+		return
+	}
+	if validTime == 0 {
+		return
+	}
+	if validTime > 0 && validTime < time.Now().Unix() {
+		return
+	}
+	hostname := fields[3]
+	if hostname == "-" || strings.HasPrefix(hostname, `broken\x20`) {
+		hostname = ""
+	}
+	if len(fields) >= 8 && fields[2] == "ipv4" {
+		mac, macErr := net.ParseMAC(fields[1])
+		if macErr != nil {
+			return
+		}
+		addressField := fields[7]
+		slashIndex := strings.IndexByte(addressField, '/')
+		if slashIndex >= 0 {
+			addressField = addressField[:slashIndex]
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(addressField))
+		if !addrOK {
+			return
+		}
+		address = address.Unmap()
+		ipToMAC[address] = mac
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			macToHostname[mac.String()] = hostname
+		}
+		return
+	}
+	var mac net.HardwareAddr
+	duidHex := fields[1]
+	duidBytes, hexErr := hex.DecodeString(duidHex)
+	if hexErr == nil {
+		mac, _ = extractMACFromDUID(duidBytes)
+	}
+	for i := 7; i < len(fields); i++ {
+		addressField := fields[i]
+		slashIndex := strings.IndexByte(addressField, '/')
+		if slashIndex >= 0 {
+			addressField = addressField[:slashIndex]
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(addressField))
+		if !addrOK {
+			continue
+		}
+		address = address.Unmap()
+		if mac != nil {
+			ipToMAC[address] = mac
+		}
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			if mac != nil {
+				macToHostname[mac.String()] = hostname
+			}
+		}
+	}
+}
+
+func parseISCDhcpd(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	scanner := bufio.NewScanner(file)
+	var currentIP netip.Addr
+	var currentMAC net.HardwareAddr
+	var currentHostname string
+	var currentActive bool
+	var inLease bool
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "lease ") && strings.HasSuffix(line, "{") {
+			ipString := strings.TrimSuffix(strings.TrimPrefix(line, "lease "), " {")
+			parsed, addrOK := netip.AddrFromSlice(net.ParseIP(ipString))
+			if addrOK {
+				currentIP = parsed.Unmap()
+				inLease = true
+				currentMAC = nil
+				currentHostname = ""
+				currentActive = false
+			}
+			continue
+		}
+		if line == "}" && inLease {
+			if currentActive && currentMAC != nil {
+				ipToMAC[currentIP] = currentMAC
+				if currentHostname != "" {
+					ipToHostname[currentIP] = currentHostname
+					macToHostname[currentMAC.String()] = currentHostname
+				}
+			} else {
+				delete(ipToMAC, currentIP)
+				delete(ipToHostname, currentIP)
+			}
+			inLease = false
+			continue
+		}
+		if !inLease {
+			continue
+		}
+		if strings.HasPrefix(line, "hardware ethernet ") {
+			macString := strings.TrimSuffix(strings.TrimPrefix(line, "hardware ethernet "), ";")
+			parsed, macErr := net.ParseMAC(macString)
+			if macErr == nil {
+				currentMAC = parsed
+			}
+		} else if strings.HasPrefix(line, "client-hostname ") {
+			hostname := strings.TrimSuffix(strings.TrimPrefix(line, "client-hostname "), ";")
+			hostname = strings.Trim(hostname, "\"")
+			if hostname != "" {
+				currentHostname = hostname
+			}
+		} else if strings.HasPrefix(line, "binding state ") {
+			state := strings.TrimSuffix(strings.TrimPrefix(line, "binding state "), ";")
+			currentActive = state == "active"
+		}
+	}
+}
+
+func parseKeaCSV4(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	scanner := bufio.NewScanner(file)
+	firstLine := true
+	for scanner.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+		fields := strings.Split(scanner.Text(), ",")
+		if len(fields) < 10 {
+			continue
+		}
+		if fields[9] != "0" {
+			continue
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[0]))
+		if !addrOK {
+			continue
+		}
+		address = address.Unmap()
+		mac, macErr := net.ParseMAC(fields[1])
+		if macErr != nil {
+			continue
+		}
+		ipToMAC[address] = mac
+		hostname := ""
+		if len(fields) > 8 {
+			hostname = fields[8]
+		}
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			macToHostname[mac.String()] = hostname
+		}
+	}
+}
+
+func parseKeaCSV6(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	scanner := bufio.NewScanner(file)
+	firstLine := true
+	for scanner.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+		fields := strings.Split(scanner.Text(), ",")
+		if len(fields) < 14 {
+			continue
+		}
+		if fields[13] != "0" {
+			continue
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[0]))
+		if !addrOK {
+			continue
+		}
+		address = address.Unmap()
+		var mac net.HardwareAddr
+		if fields[12] != "" {
+			mac, _ = net.ParseMAC(fields[12])
+		}
+		if mac == nil {
+			duid, duidErr := hex.DecodeString(strings.ReplaceAll(fields[1], ":", ""))
+			if duidErr == nil {
+				mac, _ = extractMACFromDUID(duid)
+			}
+		}
+		hostname := ""
+		if len(fields) > 11 {
+			hostname = fields[11]
+		}
+		if mac != nil {
+			ipToMAC[address] = mac
+		}
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			if mac != nil {
+				macToHostname[mac.String()] = hostname
+			}
+		}
+	}
+}
+
+func parseBootpdLeases(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	now := time.Now().Unix()
+	scanner := bufio.NewScanner(file)
+	var currentName string
+	var currentIP netip.Addr
+	var currentMAC net.HardwareAddr
+	var currentLease int64
+	var inBlock bool
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "{" {
+			inBlock = true
+			currentName = ""
+			currentIP = netip.Addr{}
+			currentMAC = nil
+			currentLease = 0
+			continue
+		}
+		if line == "}" && inBlock {
+			if currentMAC != nil && currentIP.IsValid() {
+				if currentLease == 0 || currentLease >= now {
+					ipToMAC[currentIP] = currentMAC
+					if currentName != "" {
+						ipToHostname[currentIP] = currentName
+						macToHostname[currentMAC.String()] = currentName
+					}
+				}
+			}
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		switch key {
+		case "name":
+			currentName = value
+		case "ip_address":
+			parsed, addrOK := netip.AddrFromSlice(net.ParseIP(value))
+			if addrOK {
+				currentIP = parsed.Unmap()
+			}
+		case "hw_address":
+			typeAndMAC, hasSep := strings.CutPrefix(value, "1,")
+			if hasSep {
+				mac, macErr := net.ParseMAC(typeAndMAC)
+				if macErr == nil {
+					currentMAC = mac
+				}
+			}
+		case "lease":
+			leaseHex := strings.TrimPrefix(value, "0x")
+			parsed, parseErr := strconv.ParseInt(leaseHex, 16, 64)
+			if parseErr == nil {
+				currentLease = parsed
+			}
+		}
+	}
+}

--- a/route/neighbor_resolver_linux.go
+++ b/route/neighbor_resolver_linux.go
@@ -4,7 +4,6 @@ package route
 
 import (
 	"bufio"
-	"encoding/binary"
 	"encoding/hex"
 	"net"
 	"net/netip"
@@ -204,43 +203,17 @@ func (r *neighborResolver) subscribeNeighborUpdates() {
 			continue
 		}
 		for _, message := range messages {
-			switch message.Header.Type {
-			case unix.RTM_NEWNEIGH:
-				var neighMessage rtnetlink.NeighMessage
-				unmarshalErr := neighMessage.UnmarshalBinary(message.Data)
-				if unmarshalErr != nil {
-					continue
-				}
-				if neighMessage.Attributes == nil {
-					continue
-				}
-				if neighMessage.Attributes.LLAddress == nil || len(neighMessage.Attributes.Address) == 0 {
-					continue
-				}
-				address, ok := netip.AddrFromSlice(neighMessage.Attributes.Address)
-				if !ok {
-					continue
-				}
-				r.access.Lock()
-				r.neighborIPToMAC[address] = slices.Clone(neighMessage.Attributes.LLAddress)
-				r.access.Unlock()
-			case unix.RTM_DELNEIGH:
-				var neighMessage rtnetlink.NeighMessage
-				unmarshalErr := neighMessage.UnmarshalBinary(message.Data)
-				if unmarshalErr != nil {
-					continue
-				}
-				if neighMessage.Attributes == nil || len(neighMessage.Attributes.Address) == 0 {
-					continue
-				}
-				address, ok := netip.AddrFromSlice(neighMessage.Attributes.Address)
-				if !ok {
-					continue
-				}
-				r.access.Lock()
-				delete(r.neighborIPToMAC, address)
-				r.access.Unlock()
+			address, mac, isDelete, ok := ParseNeighborMessage(message)
+			if !ok {
+				continue
 			}
+			r.access.Lock()
+			if isDelete {
+				delete(r.neighborIPToMAC, address)
+			} else {
+				r.neighborIPToMAC[address] = mac
+			}
+			r.access.Unlock()
 		}
 	}
 }
@@ -553,44 +526,4 @@ func (r *neighborResolver) parseKeaCSV6(file *os.File, ipToMAC map[netip.Addr]ne
 			}
 		}
 	}
-}
-
-func extractMACFromDUID(duid []byte) (net.HardwareAddr, bool) {
-	if len(duid) < 4 {
-		return nil, false
-	}
-	duidType := binary.BigEndian.Uint16(duid[0:2])
-	hwType := binary.BigEndian.Uint16(duid[2:4])
-	if hwType != 1 {
-		return nil, false
-	}
-	switch duidType {
-	case 1:
-		if len(duid) < 14 {
-			return nil, false
-		}
-		return net.HardwareAddr(slices.Clone(duid[8:14])), true
-	case 3:
-		if len(duid) < 10 {
-			return nil, false
-		}
-		return net.HardwareAddr(slices.Clone(duid[4:10])), true
-	}
-	return nil, false
-}
-
-func extractMACFromEUI64(address netip.Addr) (net.HardwareAddr, bool) {
-	if !address.Is6() {
-		return nil, false
-	}
-	b := address.As16()
-	if b[11] != 0xff || b[12] != 0xfe {
-		return nil, false
-	}
-	return net.HardwareAddr{b[8] ^ 0x02, b[9], b[10], b[13], b[14], b[15]}, true
-}
-
-func parseDUID(s string) ([]byte, error) {
-	cleaned := strings.ReplaceAll(s, ":", "")
-	return hex.DecodeString(cleaned)
 }

--- a/route/neighbor_resolver_linux.go
+++ b/route/neighbor_resolver_linux.go
@@ -1,0 +1,596 @@
+//go:build linux
+
+package route
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"net/netip"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sagernet/fswatch"
+	"github.com/sagernet/sing-box/adapter"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+
+	"github.com/jsimonetti/rtnetlink"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+var defaultLeaseFiles = []string{
+	"/tmp/dhcp.leases",
+	"/var/lib/dhcp/dhcpd.leases",
+	"/var/lib/dhcpd/dhcpd.leases",
+	"/var/lib/kea/kea-leases4.csv",
+	"/var/lib/kea/kea-leases6.csv",
+}
+
+type neighborResolver struct {
+	logger          logger.ContextLogger
+	leaseFiles      []string
+	access          sync.RWMutex
+	neighborIPToMAC map[netip.Addr]net.HardwareAddr
+	leaseIPToMAC    map[netip.Addr]net.HardwareAddr
+	ipToHostname    map[netip.Addr]string
+	macToHostname   map[string]string
+	watcher         *fswatch.Watcher
+	done            chan struct{}
+}
+
+func newNeighborResolver(resolverLogger logger.ContextLogger, leaseFiles []string) (adapter.NeighborResolver, error) {
+	if len(leaseFiles) == 0 {
+		for _, path := range defaultLeaseFiles {
+			info, err := os.Stat(path)
+			if err == nil && info.Size() > 0 {
+				leaseFiles = append(leaseFiles, path)
+			}
+		}
+	}
+	return &neighborResolver{
+		logger:          resolverLogger,
+		leaseFiles:      leaseFiles,
+		neighborIPToMAC: make(map[netip.Addr]net.HardwareAddr),
+		leaseIPToMAC:    make(map[netip.Addr]net.HardwareAddr),
+		ipToHostname:    make(map[netip.Addr]string),
+		macToHostname:   make(map[string]string),
+		done:            make(chan struct{}),
+	}, nil
+}
+
+func (r *neighborResolver) Start() error {
+	err := r.loadNeighborTable()
+	if err != nil {
+		r.logger.Warn(E.Cause(err, "load neighbor table"))
+	}
+	r.reloadLeaseFiles()
+	go r.subscribeNeighborUpdates()
+	if len(r.leaseFiles) > 0 {
+		watcher, err := fswatch.NewWatcher(fswatch.Options{
+			Path:   r.leaseFiles,
+			Logger: r.logger,
+			Callback: func(_ string) {
+				r.reloadLeaseFiles()
+			},
+		})
+		if err != nil {
+			r.logger.Warn(E.Cause(err, "create lease file watcher"))
+		} else {
+			r.watcher = watcher
+			err = watcher.Start()
+			if err != nil {
+				r.logger.Warn(E.Cause(err, "start lease file watcher"))
+			}
+		}
+	}
+	return nil
+}
+
+func (r *neighborResolver) Close() error {
+	close(r.done)
+	if r.watcher != nil {
+		return r.watcher.Close()
+	}
+	return nil
+}
+
+func (r *neighborResolver) LookupMAC(address netip.Addr) (net.HardwareAddr, bool) {
+	r.access.RLock()
+	defer r.access.RUnlock()
+	mac, found := r.neighborIPToMAC[address]
+	if found {
+		return mac, true
+	}
+	mac, found = r.leaseIPToMAC[address]
+	if found {
+		return mac, true
+	}
+	mac, found = extractMACFromEUI64(address)
+	if found {
+		return mac, true
+	}
+	return nil, false
+}
+
+func (r *neighborResolver) LookupHostname(address netip.Addr) (string, bool) {
+	r.access.RLock()
+	defer r.access.RUnlock()
+	hostname, found := r.ipToHostname[address]
+	if found {
+		return hostname, true
+	}
+	mac, macFound := r.neighborIPToMAC[address]
+	if !macFound {
+		mac, macFound = r.leaseIPToMAC[address]
+	}
+	if !macFound {
+		mac, macFound = extractMACFromEUI64(address)
+	}
+	if macFound {
+		hostname, found = r.macToHostname[mac.String()]
+		if found {
+			return hostname, true
+		}
+	}
+	return "", false
+}
+
+func (r *neighborResolver) loadNeighborTable() error {
+	connection, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return E.Cause(err, "dial rtnetlink")
+	}
+	defer connection.Close()
+	neighbors, err := connection.Neigh.List()
+	if err != nil {
+		return E.Cause(err, "list neighbors")
+	}
+	r.access.Lock()
+	defer r.access.Unlock()
+	for _, neigh := range neighbors {
+		if neigh.Attributes == nil {
+			continue
+		}
+		if neigh.Attributes.LLAddress == nil || len(neigh.Attributes.Address) == 0 {
+			continue
+		}
+		address, ok := netip.AddrFromSlice(neigh.Attributes.Address)
+		if !ok {
+			continue
+		}
+		r.neighborIPToMAC[address] = slices.Clone(neigh.Attributes.LLAddress)
+	}
+	return nil
+}
+
+func (r *neighborResolver) subscribeNeighborUpdates() {
+	connection, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
+		Groups: 1 << (unix.RTNLGRP_NEIGH - 1),
+	})
+	if err != nil {
+		r.logger.Warn(E.Cause(err, "subscribe neighbor updates"))
+		return
+	}
+	defer connection.Close()
+	for {
+		select {
+		case <-r.done:
+			return
+		default:
+		}
+		err = connection.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if err != nil {
+			r.logger.Warn(E.Cause(err, "set netlink read deadline"))
+			return
+		}
+		messages, err := connection.Receive()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				continue
+			}
+			select {
+			case <-r.done:
+				return
+			default:
+			}
+			r.logger.Warn(E.Cause(err, "receive neighbor update"))
+			continue
+		}
+		for _, message := range messages {
+			switch message.Header.Type {
+			case unix.RTM_NEWNEIGH:
+				var neighMessage rtnetlink.NeighMessage
+				unmarshalErr := neighMessage.UnmarshalBinary(message.Data)
+				if unmarshalErr != nil {
+					continue
+				}
+				if neighMessage.Attributes == nil {
+					continue
+				}
+				if neighMessage.Attributes.LLAddress == nil || len(neighMessage.Attributes.Address) == 0 {
+					continue
+				}
+				address, ok := netip.AddrFromSlice(neighMessage.Attributes.Address)
+				if !ok {
+					continue
+				}
+				r.access.Lock()
+				r.neighborIPToMAC[address] = slices.Clone(neighMessage.Attributes.LLAddress)
+				r.access.Unlock()
+			case unix.RTM_DELNEIGH:
+				var neighMessage rtnetlink.NeighMessage
+				unmarshalErr := neighMessage.UnmarshalBinary(message.Data)
+				if unmarshalErr != nil {
+					continue
+				}
+				if neighMessage.Attributes == nil || len(neighMessage.Attributes.Address) == 0 {
+					continue
+				}
+				address, ok := netip.AddrFromSlice(neighMessage.Attributes.Address)
+				if !ok {
+					continue
+				}
+				r.access.Lock()
+				delete(r.neighborIPToMAC, address)
+				r.access.Unlock()
+			}
+		}
+	}
+}
+
+func (r *neighborResolver) reloadLeaseFiles() {
+	leaseIPToMAC := make(map[netip.Addr]net.HardwareAddr)
+	ipToHostname := make(map[netip.Addr]string)
+	macToHostname := make(map[string]string)
+	for _, path := range r.leaseFiles {
+		r.parseLeaseFile(path, leaseIPToMAC, ipToHostname, macToHostname)
+	}
+	r.access.Lock()
+	r.leaseIPToMAC = leaseIPToMAC
+	r.ipToHostname = ipToHostname
+	r.macToHostname = macToHostname
+	r.access.Unlock()
+}
+
+func (r *neighborResolver) parseLeaseFile(path string, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	if strings.HasSuffix(path, "kea-leases4.csv") {
+		r.parseKeaCSV4(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	if strings.HasSuffix(path, "kea-leases6.csv") {
+		r.parseKeaCSV6(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	if strings.HasSuffix(path, "dhcpd.leases") {
+		r.parseISCDhcpd(file, ipToMAC, ipToHostname, macToHostname)
+		return
+	}
+	r.parseDnsmasqOdhcpd(file, ipToMAC, ipToHostname, macToHostname)
+}
+
+func (r *neighborResolver) parseDnsmasqOdhcpd(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	now := time.Now().Unix()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "duid ") {
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			r.parseOdhcpdLine(line[2:], ipToMAC, ipToHostname, macToHostname)
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		expiry, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		if expiry != 0 && expiry < now {
+			continue
+		}
+		if strings.Contains(fields[1], ":") {
+			mac, macErr := net.ParseMAC(fields[1])
+			if macErr != nil {
+				continue
+			}
+			address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[2]))
+			if !addrOK {
+				continue
+			}
+			address = address.Unmap()
+			ipToMAC[address] = mac
+			hostname := fields[3]
+			if hostname != "*" {
+				ipToHostname[address] = hostname
+				macToHostname[mac.String()] = hostname
+			}
+		} else {
+			var mac net.HardwareAddr
+			if len(fields) >= 5 {
+				duid, duidErr := parseDUID(fields[4])
+				if duidErr == nil {
+					mac, _ = extractMACFromDUID(duid)
+				}
+			}
+			address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[2]))
+			if !addrOK {
+				continue
+			}
+			address = address.Unmap()
+			if mac != nil {
+				ipToMAC[address] = mac
+			}
+			hostname := fields[3]
+			if hostname != "*" {
+				ipToHostname[address] = hostname
+				if mac != nil {
+					macToHostname[mac.String()] = hostname
+				}
+			}
+		}
+	}
+}
+
+func (r *neighborResolver) parseOdhcpdLine(line string, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return
+	}
+	validTime, err := strconv.ParseInt(fields[4], 10, 64)
+	if err != nil {
+		return
+	}
+	if validTime == 0 {
+		return
+	}
+	if validTime > 0 && validTime < time.Now().Unix() {
+		return
+	}
+	hostname := fields[3]
+	if hostname == "-" || strings.HasPrefix(hostname, `broken\x20`) {
+		hostname = ""
+	}
+	if len(fields) >= 8 && fields[2] == "ipv4" {
+		mac, macErr := net.ParseMAC(fields[1])
+		if macErr != nil {
+			return
+		}
+		addressField := fields[7]
+		slashIndex := strings.IndexByte(addressField, '/')
+		if slashIndex >= 0 {
+			addressField = addressField[:slashIndex]
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(addressField))
+		if !addrOK {
+			return
+		}
+		address = address.Unmap()
+		ipToMAC[address] = mac
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			macToHostname[mac.String()] = hostname
+		}
+		return
+	}
+	var mac net.HardwareAddr
+	duidHex := fields[1]
+	duidBytes, hexErr := hex.DecodeString(duidHex)
+	if hexErr == nil {
+		mac, _ = extractMACFromDUID(duidBytes)
+	}
+	for i := 7; i < len(fields); i++ {
+		addressField := fields[i]
+		slashIndex := strings.IndexByte(addressField, '/')
+		if slashIndex >= 0 {
+			addressField = addressField[:slashIndex]
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(addressField))
+		if !addrOK {
+			continue
+		}
+		address = address.Unmap()
+		if mac != nil {
+			ipToMAC[address] = mac
+		}
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			if mac != nil {
+				macToHostname[mac.String()] = hostname
+			}
+		}
+	}
+}
+
+func (r *neighborResolver) parseISCDhcpd(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	scanner := bufio.NewScanner(file)
+	var currentIP netip.Addr
+	var currentMAC net.HardwareAddr
+	var currentHostname string
+	var currentActive bool
+	var inLease bool
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "lease ") && strings.HasSuffix(line, "{") {
+			ipString := strings.TrimSuffix(strings.TrimPrefix(line, "lease "), " {")
+			parsed, addrOK := netip.AddrFromSlice(net.ParseIP(ipString))
+			if addrOK {
+				currentIP = parsed.Unmap()
+				inLease = true
+				currentMAC = nil
+				currentHostname = ""
+				currentActive = false
+			}
+			continue
+		}
+		if line == "}" && inLease {
+			if currentActive && currentMAC != nil {
+				ipToMAC[currentIP] = currentMAC
+				if currentHostname != "" {
+					ipToHostname[currentIP] = currentHostname
+					macToHostname[currentMAC.String()] = currentHostname
+				}
+			} else {
+				delete(ipToMAC, currentIP)
+				delete(ipToHostname, currentIP)
+			}
+			inLease = false
+			continue
+		}
+		if !inLease {
+			continue
+		}
+		if strings.HasPrefix(line, "hardware ethernet ") {
+			macString := strings.TrimSuffix(strings.TrimPrefix(line, "hardware ethernet "), ";")
+			parsed, macErr := net.ParseMAC(macString)
+			if macErr == nil {
+				currentMAC = parsed
+			}
+		} else if strings.HasPrefix(line, "client-hostname ") {
+			hostname := strings.TrimSuffix(strings.TrimPrefix(line, "client-hostname "), ";")
+			hostname = strings.Trim(hostname, "\"")
+			if hostname != "" {
+				currentHostname = hostname
+			}
+		} else if strings.HasPrefix(line, "binding state ") {
+			state := strings.TrimSuffix(strings.TrimPrefix(line, "binding state "), ";")
+			currentActive = state == "active"
+		}
+	}
+}
+
+func (r *neighborResolver) parseKeaCSV4(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	scanner := bufio.NewScanner(file)
+	firstLine := true
+	for scanner.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+		fields := strings.Split(scanner.Text(), ",")
+		if len(fields) < 10 {
+			continue
+		}
+		if fields[9] != "0" {
+			continue
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[0]))
+		if !addrOK {
+			continue
+		}
+		address = address.Unmap()
+		mac, macErr := net.ParseMAC(fields[1])
+		if macErr != nil {
+			continue
+		}
+		ipToMAC[address] = mac
+		hostname := ""
+		if len(fields) > 8 {
+			hostname = fields[8]
+		}
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			macToHostname[mac.String()] = hostname
+		}
+	}
+}
+
+func (r *neighborResolver) parseKeaCSV6(file *os.File, ipToMAC map[netip.Addr]net.HardwareAddr, ipToHostname map[netip.Addr]string, macToHostname map[string]string) {
+	scanner := bufio.NewScanner(file)
+	firstLine := true
+	for scanner.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+		fields := strings.Split(scanner.Text(), ",")
+		if len(fields) < 14 {
+			continue
+		}
+		if fields[13] != "0" {
+			continue
+		}
+		address, addrOK := netip.AddrFromSlice(net.ParseIP(fields[0]))
+		if !addrOK {
+			continue
+		}
+		address = address.Unmap()
+		var mac net.HardwareAddr
+		if fields[12] != "" {
+			mac, _ = net.ParseMAC(fields[12])
+		}
+		if mac == nil {
+			duid, duidErr := hex.DecodeString(strings.ReplaceAll(fields[1], ":", ""))
+			if duidErr == nil {
+				mac, _ = extractMACFromDUID(duid)
+			}
+		}
+		hostname := ""
+		if len(fields) > 11 {
+			hostname = fields[11]
+		}
+		if mac != nil {
+			ipToMAC[address] = mac
+		}
+		if hostname != "" {
+			ipToHostname[address] = hostname
+			if mac != nil {
+				macToHostname[mac.String()] = hostname
+			}
+		}
+	}
+}
+
+func extractMACFromDUID(duid []byte) (net.HardwareAddr, bool) {
+	if len(duid) < 4 {
+		return nil, false
+	}
+	duidType := binary.BigEndian.Uint16(duid[0:2])
+	hwType := binary.BigEndian.Uint16(duid[2:4])
+	if hwType != 1 {
+		return nil, false
+	}
+	switch duidType {
+	case 1:
+		if len(duid) < 14 {
+			return nil, false
+		}
+		return net.HardwareAddr(slices.Clone(duid[8:14])), true
+	case 3:
+		if len(duid) < 10 {
+			return nil, false
+		}
+		return net.HardwareAddr(slices.Clone(duid[4:10])), true
+	}
+	return nil, false
+}
+
+func extractMACFromEUI64(address netip.Addr) (net.HardwareAddr, bool) {
+	if !address.Is6() {
+		return nil, false
+	}
+	b := address.As16()
+	if b[11] != 0xff || b[12] != 0xfe {
+		return nil, false
+	}
+	return net.HardwareAddr{b[8] ^ 0x02, b[9], b[10], b[13], b[14], b[15]}, true
+}
+
+func parseDUID(s string) ([]byte, error) {
+	cleaned := strings.ReplaceAll(s, ":", "")
+	return hex.DecodeString(cleaned)
+}

--- a/route/neighbor_resolver_parse.go
+++ b/route/neighbor_resolver_parse.go
@@ -1,0 +1,50 @@
+package route
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"net/netip"
+	"slices"
+	"strings"
+)
+
+func extractMACFromDUID(duid []byte) (net.HardwareAddr, bool) {
+	if len(duid) < 4 {
+		return nil, false
+	}
+	duidType := binary.BigEndian.Uint16(duid[0:2])
+	hwType := binary.BigEndian.Uint16(duid[2:4])
+	if hwType != 1 {
+		return nil, false
+	}
+	switch duidType {
+	case 1:
+		if len(duid) < 14 {
+			return nil, false
+		}
+		return net.HardwareAddr(slices.Clone(duid[8:14])), true
+	case 3:
+		if len(duid) < 10 {
+			return nil, false
+		}
+		return net.HardwareAddr(slices.Clone(duid[4:10])), true
+	}
+	return nil, false
+}
+
+func extractMACFromEUI64(address netip.Addr) (net.HardwareAddr, bool) {
+	if !address.Is6() {
+		return nil, false
+	}
+	b := address.As16()
+	if b[11] != 0xff || b[12] != 0xfe {
+		return nil, false
+	}
+	return net.HardwareAddr{b[8] ^ 0x02, b[9], b[10], b[13], b[14], b[15]}, true
+}
+
+func parseDUID(s string) ([]byte, error) {
+	cleaned := strings.ReplaceAll(s, ":", "")
+	return hex.DecodeString(cleaned)
+}

--- a/route/neighbor_resolver_platform.go
+++ b/route/neighbor_resolver_platform.go
@@ -1,0 +1,84 @@
+package route
+
+import (
+	"net"
+	"net/netip"
+	"sync"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/common/logger"
+)
+
+type platformNeighborResolver struct {
+	logger        logger.ContextLogger
+	platform      adapter.PlatformInterface
+	access        sync.RWMutex
+	ipToMAC       map[netip.Addr]net.HardwareAddr
+	ipToHostname  map[netip.Addr]string
+	macToHostname map[string]string
+}
+
+func newPlatformNeighborResolver(resolverLogger logger.ContextLogger, platform adapter.PlatformInterface) adapter.NeighborResolver {
+	return &platformNeighborResolver{
+		logger:        resolverLogger,
+		platform:      platform,
+		ipToMAC:       make(map[netip.Addr]net.HardwareAddr),
+		ipToHostname:  make(map[netip.Addr]string),
+		macToHostname: make(map[string]string),
+	}
+}
+
+func (r *platformNeighborResolver) Start() error {
+	return r.platform.StartNeighborMonitor(r)
+}
+
+func (r *platformNeighborResolver) Close() error {
+	return r.platform.CloseNeighborMonitor(r)
+}
+
+func (r *platformNeighborResolver) LookupMAC(address netip.Addr) (net.HardwareAddr, bool) {
+	r.access.RLock()
+	defer r.access.RUnlock()
+	mac, found := r.ipToMAC[address]
+	if found {
+		return mac, true
+	}
+	return extractMACFromEUI64(address)
+}
+
+func (r *platformNeighborResolver) LookupHostname(address netip.Addr) (string, bool) {
+	r.access.RLock()
+	defer r.access.RUnlock()
+	hostname, found := r.ipToHostname[address]
+	if found {
+		return hostname, true
+	}
+	mac, found := r.ipToMAC[address]
+	if !found {
+		mac, found = extractMACFromEUI64(address)
+	}
+	if !found {
+		return "", false
+	}
+	hostname, found = r.macToHostname[mac.String()]
+	return hostname, found
+}
+
+func (r *platformNeighborResolver) UpdateNeighborTable(entries []adapter.NeighborEntry) {
+	ipToMAC := make(map[netip.Addr]net.HardwareAddr)
+	ipToHostname := make(map[netip.Addr]string)
+	macToHostname := make(map[string]string)
+	for _, entry := range entries {
+		ipToMAC[entry.Address] = entry.MACAddress
+		if entry.Hostname != "" {
+			ipToHostname[entry.Address] = entry.Hostname
+			macToHostname[entry.MACAddress.String()] = entry.Hostname
+		}
+	}
+	r.access.Lock()
+	r.ipToMAC = ipToMAC
+	r.ipToHostname = ipToHostname
+	r.macToHostname = macToHostname
+	r.access.Unlock()
+	r.logger.Info("updated neighbor table: ", len(entries), " entries")
+}

--- a/route/neighbor_resolver_stub.go
+++ b/route/neighbor_resolver_stub.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package route
 

--- a/route/neighbor_resolver_stub.go
+++ b/route/neighbor_resolver_stub.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package route
+
+import (
+	"os"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/common/logger"
+)
+
+func newNeighborResolver(_ logger.ContextLogger, _ []string) (adapter.NeighborResolver, error) {
+	return nil, os.ErrInvalid
+}

--- a/route/neighbor_table_darwin.go
+++ b/route/neighbor_table_darwin.go
@@ -1,0 +1,104 @@
+//go:build darwin
+
+package route
+
+import (
+	"net"
+	"net/netip"
+	"syscall"
+
+	"github.com/sagernet/sing-box/adapter"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"golang.org/x/net/route"
+	"golang.org/x/sys/unix"
+)
+
+func ReadNeighborEntries() ([]adapter.NeighborEntry, error) {
+	var entries []adapter.NeighborEntry
+	ipv4Entries, err := readNeighborEntriesAF(syscall.AF_INET)
+	if err != nil {
+		return nil, E.Cause(err, "read IPv4 neighbors")
+	}
+	entries = append(entries, ipv4Entries...)
+	ipv6Entries, err := readNeighborEntriesAF(syscall.AF_INET6)
+	if err != nil {
+		return nil, E.Cause(err, "read IPv6 neighbors")
+	}
+	entries = append(entries, ipv6Entries...)
+	return entries, nil
+}
+
+func readNeighborEntriesAF(addressFamily int) ([]adapter.NeighborEntry, error) {
+	rib, err := route.FetchRIB(addressFamily, route.RIBType(syscall.NET_RT_FLAGS), syscall.RTF_LLINFO)
+	if err != nil {
+		return nil, err
+	}
+	messages, err := route.ParseRIB(route.RIBType(syscall.NET_RT_FLAGS), rib)
+	if err != nil {
+		return nil, err
+	}
+	var entries []adapter.NeighborEntry
+	for _, message := range messages {
+		routeMessage, isRouteMessage := message.(*route.RouteMessage)
+		if !isRouteMessage {
+			continue
+		}
+		address, macAddress, ok := parseRouteNeighborEntry(routeMessage)
+		if !ok {
+			continue
+		}
+		entries = append(entries, adapter.NeighborEntry{
+			Address:    address,
+			MACAddress: macAddress,
+		})
+	}
+	return entries, nil
+}
+
+func parseRouteNeighborEntry(message *route.RouteMessage) (address netip.Addr, macAddress net.HardwareAddr, ok bool) {
+	if len(message.Addrs) <= unix.RTAX_GATEWAY {
+		return
+	}
+	gateway, isLinkAddr := message.Addrs[unix.RTAX_GATEWAY].(*route.LinkAddr)
+	if !isLinkAddr || len(gateway.Addr) < 6 {
+		return
+	}
+	switch destination := message.Addrs[unix.RTAX_DST].(type) {
+	case *route.Inet4Addr:
+		address = netip.AddrFrom4(destination.IP)
+	case *route.Inet6Addr:
+		address = netip.AddrFrom16(destination.IP)
+	default:
+		return
+	}
+	macAddress = net.HardwareAddr(make([]byte, len(gateway.Addr)))
+	copy(macAddress, gateway.Addr)
+	ok = true
+	return
+}
+
+func ParseRouteNeighborMessage(message *route.RouteMessage) (address netip.Addr, macAddress net.HardwareAddr, isDelete bool, ok bool) {
+	isDelete = message.Type == unix.RTM_DELETE
+	if len(message.Addrs) <= unix.RTAX_GATEWAY {
+		return
+	}
+	switch destination := message.Addrs[unix.RTAX_DST].(type) {
+	case *route.Inet4Addr:
+		address = netip.AddrFrom4(destination.IP)
+	case *route.Inet6Addr:
+		address = netip.AddrFrom16(destination.IP)
+	default:
+		return
+	}
+	if !isDelete {
+		gateway, isLinkAddr := message.Addrs[unix.RTAX_GATEWAY].(*route.LinkAddr)
+		if !isLinkAddr || len(gateway.Addr) < 6 {
+			return
+		}
+		macAddress = net.HardwareAddr(make([]byte, len(gateway.Addr)))
+		copy(macAddress, gateway.Addr)
+	}
+	ok = true
+	return
+}

--- a/route/neighbor_table_linux.go
+++ b/route/neighbor_table_linux.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package route
+
+import (
+	"net"
+	"net/netip"
+	"slices"
+
+	"github.com/sagernet/sing-box/adapter"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/jsimonetti/rtnetlink"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func ReadNeighborEntries() ([]adapter.NeighborEntry, error) {
+	connection, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return nil, E.Cause(err, "dial rtnetlink")
+	}
+	defer connection.Close()
+	neighbors, err := connection.Neigh.List()
+	if err != nil {
+		return nil, E.Cause(err, "list neighbors")
+	}
+	var entries []adapter.NeighborEntry
+	for _, neighbor := range neighbors {
+		if neighbor.Attributes == nil {
+			continue
+		}
+		if neighbor.Attributes.LLAddress == nil || len(neighbor.Attributes.Address) == 0 {
+			continue
+		}
+		address, ok := netip.AddrFromSlice(neighbor.Attributes.Address)
+		if !ok {
+			continue
+		}
+		entries = append(entries, adapter.NeighborEntry{
+			Address:    address,
+			MACAddress: slices.Clone(neighbor.Attributes.LLAddress),
+		})
+	}
+	return entries, nil
+}
+
+func ParseNeighborMessage(message netlink.Message) (address netip.Addr, macAddress net.HardwareAddr, isDelete bool, ok bool) {
+	var neighMessage rtnetlink.NeighMessage
+	err := neighMessage.UnmarshalBinary(message.Data)
+	if err != nil {
+		return
+	}
+	if neighMessage.Attributes == nil || len(neighMessage.Attributes.Address) == 0 {
+		return
+	}
+	address, ok = netip.AddrFromSlice(neighMessage.Attributes.Address)
+	if !ok {
+		return
+	}
+	isDelete = message.Header.Type == unix.RTM_DELNEIGH
+	if !isDelete && neighMessage.Attributes.LLAddress == nil {
+		ok = false
+		return
+	}
+	macAddress = slices.Clone(neighMessage.Attributes.LLAddress)
+	return
+}

--- a/route/route.go
+++ b/route/route.go
@@ -439,6 +439,23 @@ func (r *Router) matchRule(
 			metadata.ProcessInfo = processInfo
 		}
 	}
+	if r.neighborResolver != nil && metadata.SourceMACAddress == nil && metadata.Source.Addr.IsValid() {
+		mac, macFound := r.neighborResolver.LookupMAC(metadata.Source.Addr)
+		if macFound {
+			metadata.SourceMACAddress = mac
+		}
+		hostname, hostnameFound := r.neighborResolver.LookupHostname(metadata.Source.Addr)
+		if hostnameFound {
+			metadata.SourceHostname = hostname
+			if macFound {
+				r.logger.InfoContext(ctx, "found neighbor: ", mac, ", hostname: ", hostname)
+			} else {
+				r.logger.InfoContext(ctx, "found neighbor hostname: ", hostname)
+			}
+		} else if macFound {
+			r.logger.InfoContext(ctx, "found neighbor: ", mac)
+		}
+	}
 	if metadata.Destination.Addr.IsValid() && r.dnsTransport.FakeIP() != nil && r.dnsTransport.FakeIP().Store().Contains(metadata.Destination.Addr) {
 		domain, loaded := r.dnsTransport.FakeIP().Store().Lookup(metadata.Destination.Addr)
 		if !loaded {

--- a/route/router.go
+++ b/route/router.go
@@ -149,19 +149,32 @@ func (r *Router) Start(stage adapter.StartStage) error {
 		}
 		r.needFindNeighbor = needFindNeighbor
 		if needFindNeighbor {
-			monitor.Start("initialize neighbor resolver")
-			resolver, err := newNeighborResolver(r.logger, r.leaseFiles)
-			monitor.Finish()
-			if err != nil {
-				if err != os.ErrInvalid {
-					r.logger.Warn(E.Cause(err, "create neighbor resolver"))
-				}
-			} else {
-				err = resolver.Start()
+			if r.platformInterface != nil && r.platformInterface.UsePlatformNeighborResolver() {
+				monitor.Start("initialize neighbor resolver")
+				resolver := newPlatformNeighborResolver(r.logger, r.platformInterface)
+				err := resolver.Start()
+				monitor.Finish()
 				if err != nil {
-					r.logger.Warn(E.Cause(err, "start neighbor resolver"))
+					r.logger.Error(E.Cause(err, "start neighbor resolver"))
 				} else {
 					r.neighborResolver = resolver
+				}
+			}
+			if r.neighborResolver == nil {
+				monitor.Start("initialize neighbor resolver")
+				resolver, err := newNeighborResolver(r.logger, r.leaseFiles)
+				monitor.Finish()
+				if err != nil {
+					if err != os.ErrInvalid {
+						r.logger.Error(E.Cause(err, "create neighbor resolver"))
+					}
+				} else {
+					err = resolver.Start()
+					if err != nil {
+						r.logger.Error(E.Cause(err, "start neighbor resolver"))
+					} else {
+						r.neighborResolver = resolver
+					}
 				}
 			}
 		}

--- a/route/router.go
+++ b/route/router.go
@@ -159,8 +159,7 @@ func (r *Router) Start(stage adapter.StartStage) error {
 				} else {
 					r.neighborResolver = resolver
 				}
-			}
-			if r.neighborResolver == nil {
+			} else {
 				monitor.Start("initialize neighbor resolver")
 				resolver, err := newNeighborResolver(r.logger, r.leaseFiles)
 				monitor.Finish()

--- a/route/router.go
+++ b/route/router.go
@@ -31,9 +31,12 @@ type Router struct {
 	network           adapter.NetworkManager
 	rules             []adapter.Rule
 	needFindProcess   bool
+	needFindNeighbor  bool
+	leaseFiles        []string
 	ruleSets          []adapter.RuleSet
 	ruleSetMap        map[string]adapter.RuleSet
 	processSearcher   process.Searcher
+	neighborResolver  adapter.NeighborResolver
 	pauseManager      pause.Manager
 	trackers          []adapter.ConnectionTracker
 	platformInterface adapter.PlatformInterface
@@ -53,6 +56,8 @@ func NewRouter(ctx context.Context, logFactory log.Factory, options option.Route
 		rules:             make([]adapter.Rule, 0, len(options.Rules)),
 		ruleSetMap:        make(map[string]adapter.RuleSet),
 		needFindProcess:   hasRule(options.Rules, isProcessRule) || hasDNSRule(dnsOptions.Rules, isProcessDNSRule) || options.FindProcess,
+		needFindNeighbor:  hasRule(options.Rules, isNeighborRule) || hasDNSRule(dnsOptions.Rules, isNeighborDNSRule) || options.FindNeighbor,
+		leaseFiles:        options.DHCPLeaseFiles,
 		pauseManager:      service.FromContext[pause.Manager](ctx),
 		platformInterface: service.FromContext[adapter.PlatformInterface](ctx),
 	}
@@ -112,6 +117,7 @@ func (r *Router) Start(stage adapter.StartStage) error {
 		}
 		r.network.Initialize(r.ruleSets)
 		needFindProcess := r.needFindProcess
+		needFindNeighbor := r.needFindNeighbor
 		for _, ruleSet := range r.ruleSets {
 			metadata := ruleSet.Metadata()
 			if metadata.ContainsProcessRule {
@@ -138,6 +144,24 @@ func (r *Router) Start(stage adapter.StartStage) error {
 					}
 				} else {
 					r.processSearcher = searcher
+				}
+			}
+		}
+		r.needFindNeighbor = needFindNeighbor
+		if needFindNeighbor {
+			monitor.Start("initialize neighbor resolver")
+			resolver, err := newNeighborResolver(r.logger, r.leaseFiles)
+			monitor.Finish()
+			if err != nil {
+				if err != os.ErrInvalid {
+					r.logger.Warn(E.Cause(err, "create neighbor resolver"))
+				}
+			} else {
+				err = resolver.Start()
+				if err != nil {
+					r.logger.Warn(E.Cause(err, "start neighbor resolver"))
+				} else {
+					r.neighborResolver = resolver
 				}
 			}
 		}
@@ -172,6 +196,13 @@ func (r *Router) Start(stage adapter.StartStage) error {
 func (r *Router) Close() error {
 	monitor := taskmonitor.New(r.logger, C.StopTimeout)
 	var err error
+	if r.neighborResolver != nil {
+		monitor.Start("close neighbor resolver")
+		err = E.Append(err, r.neighborResolver.Close(), func(closeErr error) error {
+			return E.Cause(closeErr, "close neighbor resolver")
+		})
+		monitor.Finish()
+	}
 	for i, rule := range r.rules {
 		monitor.Start("close rule[", i, "]")
 		err = E.Append(err, rule.Close(), func(err error) error {
@@ -204,6 +235,14 @@ func (r *Router) AppendTracker(tracker adapter.ConnectionTracker) {
 
 func (r *Router) NeedFindProcess() bool {
 	return r.needFindProcess
+}
+
+func (r *Router) NeedFindNeighbor() bool {
+	return r.needFindNeighbor
+}
+
+func (r *Router) NeighborResolver() adapter.NeighborResolver {
+	return r.neighborResolver
 }
 
 func (r *Router) ResetNetwork() {

--- a/route/rule/rule_default.go
+++ b/route/rule/rule_default.go
@@ -260,6 +260,16 @@ func NewDefaultRule(ctx context.Context, logger log.ContextLogger, options optio
 		rule.items = append(rule.items, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.SourceMACAddress) > 0 {
+		item := NewSourceMACAddressItem(options.SourceMACAddress)
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
+	if len(options.SourceHostname) > 0 {
+		item := NewSourceHostnameItem(options.SourceHostname)
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.PreferredBy) > 0 {
 		item := NewPreferredByItem(ctx, options.PreferredBy)
 		rule.items = append(rule.items, item)

--- a/route/rule/rule_dns.go
+++ b/route/rule/rule_dns.go
@@ -261,6 +261,16 @@ func NewDefaultDNSRule(ctx context.Context, logger log.ContextLogger, options op
 		rule.items = append(rule.items, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.SourceMACAddress) > 0 {
+		item := NewSourceMACAddressItem(options.SourceMACAddress)
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
+	if len(options.SourceHostname) > 0 {
+		item := NewSourceHostnameItem(options.SourceHostname)
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.RuleSet) > 0 {
 		//nolint:staticcheck
 		if options.Deprecated_RulesetIPCIDRMatchSource {

--- a/route/rule/rule_item_source_hostname.go
+++ b/route/rule/rule_item_source_hostname.go
@@ -1,0 +1,42 @@
+package rule
+
+import (
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+)
+
+var _ RuleItem = (*SourceHostnameItem)(nil)
+
+type SourceHostnameItem struct {
+	hostnames   []string
+	hostnameMap map[string]bool
+}
+
+func NewSourceHostnameItem(hostnameList []string) *SourceHostnameItem {
+	rule := &SourceHostnameItem{
+		hostnames:   hostnameList,
+		hostnameMap: make(map[string]bool),
+	}
+	for _, hostname := range hostnameList {
+		rule.hostnameMap[hostname] = true
+	}
+	return rule
+}
+
+func (r *SourceHostnameItem) Match(metadata *adapter.InboundContext) bool {
+	if metadata.SourceHostname == "" {
+		return false
+	}
+	return r.hostnameMap[metadata.SourceHostname]
+}
+
+func (r *SourceHostnameItem) String() string {
+	var description string
+	if len(r.hostnames) == 1 {
+		description = "source_hostname=" + r.hostnames[0]
+	} else {
+		description = "source_hostname=[" + strings.Join(r.hostnames, " ") + "]"
+	}
+	return description
+}

--- a/route/rule/rule_item_source_mac_address.go
+++ b/route/rule/rule_item_source_mac_address.go
@@ -1,0 +1,48 @@
+package rule
+
+import (
+	"net"
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+)
+
+var _ RuleItem = (*SourceMACAddressItem)(nil)
+
+type SourceMACAddressItem struct {
+	addresses  []string
+	addressMap map[string]bool
+}
+
+func NewSourceMACAddressItem(addressList []string) *SourceMACAddressItem {
+	rule := &SourceMACAddressItem{
+		addresses:  addressList,
+		addressMap: make(map[string]bool),
+	}
+	for _, address := range addressList {
+		parsed, err := net.ParseMAC(address)
+		if err == nil {
+			rule.addressMap[parsed.String()] = true
+		} else {
+			rule.addressMap[address] = true
+		}
+	}
+	return rule
+}
+
+func (r *SourceMACAddressItem) Match(metadata *adapter.InboundContext) bool {
+	if metadata.SourceMACAddress == nil {
+		return false
+	}
+	return r.addressMap[metadata.SourceMACAddress.String()]
+}
+
+func (r *SourceMACAddressItem) String() string {
+	var description string
+	if len(r.addresses) == 1 {
+		description = "source_mac_address=" + r.addresses[0]
+	} else {
+		description = "source_mac_address=[" + strings.Join(r.addresses, " ") + "]"
+	}
+	return description
+}

--- a/route/rule_conds.go
+++ b/route/rule_conds.go
@@ -45,6 +45,14 @@ func isProcessDNSRule(rule option.DefaultDNSRule) bool {
 	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0 || len(rule.User) > 0 || len(rule.UserID) > 0
 }
 
+func isNeighborRule(rule option.DefaultRule) bool {
+	return len(rule.SourceMACAddress) > 0 || len(rule.SourceHostname) > 0
+}
+
+func isNeighborDNSRule(rule option.DefaultDNSRule) bool {
+	return len(rule.SourceMACAddress) > 0 || len(rule.SourceHostname) > 0
+}
+
 func isWIFIRule(rule option.DefaultRule) bool {
 	return len(rule.WIFISSID) > 0 || len(rule.WIFIBSSID) > 0
 }

--- a/transport/v2raygrpc/client.go
+++ b/transport/v2raygrpc/client.go
@@ -106,7 +106,7 @@ func (c *Client) DialContext(ctx context.Context) (net.Conn, error) {
 		cancel(err)
 		return nil, err
 	}
-	return NewGRPCConn(stream), nil
+	return NewGRPCConn(stream, cancel), nil
 }
 
 func (c *Client) Close() error {

--- a/transport/v2raygrpc/conn.go
+++ b/transport/v2raygrpc/conn.go
@@ -1,6 +1,7 @@
 package v2raygrpc
 
 import (
+	"context"
 	"net"
 	"os"
 	"time"
@@ -14,16 +15,18 @@ var _ net.Conn = (*GRPCConn)(nil)
 
 type GRPCConn struct {
 	GunService
-	cache []byte
+	cache  []byte
+	cancel context.CancelCauseFunc
 }
 
-func NewGRPCConn(service GunService) *GRPCConn {
+func NewGRPCConn(service GunService, cancel context.CancelCauseFunc) *GRPCConn {
 	//nolint:staticcheck
 	if client, isClient := service.(GunService_TunClient); isClient {
 		service = &clientConnWrapper{client}
 	}
 	return &GRPCConn{
 		GunService: service,
+		cancel:     cancel,
 	}
 }
 
@@ -54,6 +57,9 @@ func (c *GRPCConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *GRPCConn) Close() error {
+	if c.cancel != nil {
+		c.cancel(nil)
+	}
 	return nil
 }
 

--- a/transport/v2raygrpc/server.go
+++ b/transport/v2raygrpc/server.go
@@ -52,7 +52,7 @@ func NewServer(ctx context.Context, logger logger.ContextLogger, options option.
 }
 
 func (s *Server) Tun(server GunService_TunServer) error {
-	conn := NewGRPCConn(server)
+	conn := NewGRPCConn(server, nil)
 	var source M.Socksaddr
 	if remotePeer, loaded := peer.FromContext(server.Context()); loaded {
 		source = M.SocksaddrFromNet(remotePeer.Addr)


### PR DESCRIPTION
This fix addresses a regression where DNS queries via gRPC detour failed with "closed pipe", and a subsequent bug where HTTPS DNS failed due to Context value loss and singleflight deadlocks during recursive lookups.

The original fix for gRPC detached the dial context from the request to maintain long-lived streams, but this inadvertently stripped essential metadata (Values/Deadlines) and created a deadlock when a dialer (like DoH) triggered a nested DNS query to the same transport.

Improvements:
- dns/connector: Implemented recursive lookup detection using context values to prevent deadlocks when a dialer triggers another DNS query to the same transport.
- dns/connector: Introduced a value-propagating Context wrapper to ensure dialers receive necessary metadata while still maintaining the connection's long-term lifecycle tied to the connector.
- transport/v2raygrpc: Ensured proper stream closure by passing the cancellation function to GRPCConn.