### PR TITLE
service/ccm: strip Accept-Encoding before forwarding to avoid untracked usage

### DIFF
--- a/service/ccm/service.go
+++ b/service/ccm/service.go
@@ -362,6 +362,13 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	serviceOverridesAcceptEncoding := len(s.httpHeaders.Values("Accept-Encoding")) > 0
+	if s.usageTracker != nil && !serviceOverridesAcceptEncoding {
+		// Strip Accept-Encoding so Go Transport adds it automatically
+		// and transparently decompresses the response for correct usage counting.
+		proxyRequest.Header.Del("Accept-Encoding")
+	}
+
 	anthropicBetaHeader := proxyRequest.Header.Get("anthropic-beta")
 	if anthropicBetaHeader != "" {
 		proxyRequest.Header.Set("anthropic-beta", anthropicBetaOAuthValue+","+anthropicBetaHeader)


### PR DESCRIPTION
## Problem

When clients (e.g. the Node.js Anthropic SDK used by Claude Code CLI and VS Code extension) explicitly set `Accept-Encoding: gzip`, CCM forwards that header to Anthropic. Anthropic responds with a gzip-compressed body.

Go's `http.Transport` transparently decompresses a response **only** when it added `Accept-Encoding` itself. If the header is set explicitly by the application, the transport leaves the body compressed. As a result, CCM receives raw gzip bytes in `response.Body`. The `json.Unmarshal` call silently fails, and the usage counter is never updated.

This affects any client that sets `Accept-Encoding` explicitly — notably the Node.js `@anthropic-ai/sdk` used by Claude Code.

## Fix

Remove `Accept-Encoding` from the outgoing proxy request before `httpClient.Do()`. The transport will then add the header itself and transparently decompress the response body, so CCM always sees clean JSON/SSE — regardless of what the original client sent.

## Effect on wire compression

- **CCM → Anthropic**: gzip compression is **preserved** — the transport negotiates it automatically.
- **CCM → localhost client**: response is decompressed. Compression on a loopback interface has no practical benefit.

## Diff

```go
proxyRequest.Header.Set("Authorization", "Bearer "+accessToken)

// Strip Accept-Encoding so Go Transport adds it automatically
// and transparently decompresses the response for correct usage counting.
proxyRequest.Header.Del("Accept-Encoding")

response, err := s.httpClient.Do(proxyRequest)
```

Verified: after this fix, curl requests with `Accept-Encoding: gzip` and Claude Code CLI sessions are correctly recorded in `ccm-usages.json`.