### PR TITLE
Fix DNS transport hangs and resolution failures

### DIFF
--- a/dns/transport/base.go
+++ b/dns/transport/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"time"
 
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/dns"
@@ -137,7 +138,31 @@ func (t *BaseTransport) Shutdown(ctx context.Context) error {
 }
 
 func (t *BaseTransport) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), C.TCPTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), C.StopTimeout)
 	defer cancel()
 	return t.Shutdown(ctx)
+}
+
+func (t *BaseTransport) ContextWithCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+	connCtx, cancel := context.WithCancel(t.closeCtx)
+	stop := context.AfterFunc(ctx, func() {
+		cancel()
+	})
+	return joinedContext{connCtx, ctx}, func() {
+		stop()
+		cancel()
+	}
+}
+
+type joinedContext struct {
+	context.Context
+	parent context.Context
+}
+
+func (v joinedContext) Value(key any) any {
+	return v.parent.Value(key)
+}
+
+func (v joinedContext) Deadline() (time.Time, bool) {
+	return v.parent.Deadline()
 }

--- a/dns/transport/base.go
+++ b/dns/transport/base.go
@@ -110,19 +110,17 @@ func (t *BaseTransport) Shutdown(ctx context.Context) error {
 	}
 
 	t.state = StateClosing
+	t.closeCancel()
 
 	if t.inFlight == 0 {
 		t.state = StateClosed
 		t.mutex.Unlock()
-		t.closeCancel()
 		return nil
 	}
 
 	t.queriesComplete = make(chan struct{})
 	queriesComplete := t.queriesComplete
 	t.mutex.Unlock()
-
-	t.closeCancel()
 
 	select {
 	case <-queriesComplete:

--- a/dns/transport/connector.go
+++ b/dns/transport/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"sync"
-	"time"
 
 	E "github.com/sagernet/sing/common/exceptions"
 )
@@ -184,51 +183,12 @@ func (c *Connector[T]) dialWithCancellation(ctx context.Context) (T, context.Can
 	}
 	connCtx, cancel := context.WithCancel(c.closeCtx)
 
-	var (
-		stateAccess  sync.Mutex
-		dialComplete bool
-	)
-	stopCancel := context.AfterFunc(ctx, func() {
-		stateAccess.Lock()
-		if !dialComplete {
-			cancel()
-		}
-		stateAccess.Unlock()
-	})
-	select {
-	case <-ctx.Done():
-		stateAccess.Lock()
-		dialComplete = true
-		stateAccess.Unlock()
-		stopCancel()
-		cancel()
-		return zero, nil, ctx.Err()
-	default:
-	}
-
-	connection, err := c.dial(valueContext{connCtx, ctx})
-	stateAccess.Lock()
-	dialComplete = true
-	stateAccess.Unlock()
-	stopCancel()
+	connection, err := c.dial(joinedContext{connCtx, ctx})
 	if err != nil {
 		cancel()
 		return zero, nil, err
 	}
 	return connection, cancel, nil
-}
-
-type valueContext struct {
-	context.Context
-	parent context.Context
-}
-
-func (v valueContext) Value(key any) any {
-	return v.parent.Value(key)
-}
-
-func (v valueContext) Deadline() (time.Time, bool) {
-	return v.parent.Deadline()
 }
 
 func (c *Connector[T]) Close() error {

--- a/dns/transport/connector_test.go
+++ b/dns/transport/connector_test.go
@@ -146,57 +146,6 @@ func TestConnectorDialSkipsCanceledRequest(t *testing.T) {
 	require.EqualValues(t, 0, dialCount.Load())
 }
 
-func TestConnectorCanceledRequestDoesNotCacheConnection(t *testing.T) {
-	t.Parallel()
-
-	var (
-		dialCount  atomic.Int32
-		closeCount atomic.Int32
-	)
-	dialStarted := make(chan struct{}, 1)
-	releaseDial := make(chan struct{})
-
-	connector := NewConnector(context.Background(), func(ctx context.Context) (*testConnectorConnection, error) {
-		dialCount.Add(1)
-		select {
-		case dialStarted <- struct{}{}:
-		default:
-		}
-		<-releaseDial
-		return &testConnectorConnection{}, nil
-	}, ConnectorCallbacks[*testConnectorConnection]{
-		IsClosed: func(connection *testConnectorConnection) bool {
-			return false
-		},
-		Close: func(connection *testConnectorConnection) {
-			closeCount.Add(1)
-		},
-		Reset: func(connection *testConnectorConnection) {},
-	})
-
-	requestContext, cancel := context.WithCancel(context.Background())
-	result := make(chan error, 1)
-	go func() {
-		_, err := connector.Get(requestContext)
-		result <- err
-	}()
-
-	<-dialStarted
-	cancel()
-	close(releaseDial)
-
-	err := <-result
-	require.ErrorIs(t, err, context.Canceled)
-	require.EqualValues(t, 1, dialCount.Load())
-	require.Eventually(t, func() bool {
-		return closeCount.Load() == 1
-	}, time.Second, 10*time.Millisecond)
-
-	_, err = connector.Get(context.Background())
-	require.NoError(t, err)
-	require.EqualValues(t, 2, dialCount.Load())
-}
-
 func TestConnectorCanceledRequestReturnsBeforeIgnoredDialCompletes(t *testing.T) {
 	t.Parallel()
 

--- a/dns/transport/quic/quic.go
+++ b/dns/transport/quic/quic.go
@@ -133,6 +133,9 @@ func (t *Transport) Exchange(ctx context.Context, message *mDNS.Msg) (*mDNS.Msg,
 	}
 	defer t.EndQuery()
 
+	ctx, cancel := t.BaseTransport.ContextWithCancel(ctx)
+	defer cancel()
+
 	var (
 		conn     *quic.Conn
 		err      error

--- a/dns/transport/tls.go
+++ b/dns/transport/tls.go
@@ -109,6 +109,9 @@ func (t *TLSTransport) Exchange(ctx context.Context, message *mDNS.Msg) (*mDNS.M
 	}
 	defer t.EndQuery()
 
+	ctx, cancel := t.ContextWithCancel(ctx)
+	defer cancel()
+
 	t.access.Lock()
 	conn := t.connections.PopFront()
 	t.access.Unlock()
@@ -130,6 +133,10 @@ func (t *TLSTransport) exchange(ctx context.Context, message *mDNS.Msg, conn *tl
 	if deadline, ok := ctx.Deadline(); ok {
 		conn.SetDeadline(deadline)
 	}
+	stop := context.AfterFunc(ctx, func() {
+		conn.SetDeadline(time.Unix(0, 1))
+	})
+	defer stop()
 	conn.queryId++
 	err := WriteMessage(conn, conn.queryId, message)
 	if err != nil {

--- a/dns/transport/udp.go
+++ b/dns/transport/udp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/common/dialer"
@@ -95,7 +96,7 @@ func (t *UDPTransport) Start(stage adapter.StartStage) error {
 }
 
 func (t *UDPTransport) Close() error {
-	return E.Errors(t.BaseTransport.Close(), t.connector.Close())
+	return E.Errors(t.connector.Close(), t.BaseTransport.Close())
 }
 
 func (t *UDPTransport) Reset() {
@@ -121,11 +122,17 @@ func (t *UDPTransport) Exchange(ctx context.Context, message *mDNS.Msg) (*mDNS.M
 	}
 	defer t.EndQuery()
 
+	ctx, cancel := t.ContextWithCancel(ctx)
+	defer cancel()
+
 	response, err := t.exchange(ctx, message)
 	if err != nil {
 		return nil, err
 	}
 	if response.Truncated {
+		if t.State() >= StateClosing {
+			return nil, ErrTransportClosed
+		}
 		t.Logger.InfoContext(ctx, "response truncated, retrying with TCP")
 		return t.exchangeTCP(ctx, message)
 	}
@@ -138,6 +145,13 @@ func (t *UDPTransport) exchangeTCP(ctx context.Context, message *mDNS.Msg) (*mDN
 		return nil, E.Cause(err, "dial TCP connection")
 	}
 	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetDeadline(deadline)
+	}
+	stop := context.AfterFunc(ctx, func() {
+		conn.SetDeadline(time.Unix(0, 1))
+	})
+	defer stop()
 	err = WriteMessage(conn, message.Id, message)
 	if err != nil {
 		return nil, E.Cause(err, "write request")
@@ -200,6 +214,14 @@ func (t *UDPTransport) exchange(ctx context.Context, message *mDNS.Msg) (*mDNS.M
 	if err != nil {
 		return nil, err
 	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetDeadline(deadline)
+	}
+	stop := context.AfterFunc(ctx, func() {
+		conn.SetDeadline(time.Unix(0, 1))
+	})
+	defer stop()
 
 	_, err = conn.Write(rawMessage)
 	if err != nil {

--- a/dns/transport_manager.go
+++ b/dns/transport_manager.go
@@ -146,7 +146,6 @@ func (m *TransportManager) startTransports(transports []adapter.DNSTransport) er
 }
 
 func (m *TransportManager) Close() error {
-	monitor := taskmonitor.New(m.logger, C.StopTimeout)
 	m.access.Lock()
 	if !m.started {
 		m.access.Unlock()
@@ -156,17 +155,34 @@ func (m *TransportManager) Close() error {
 	transports := m.transports
 	m.transports = nil
 	m.access.Unlock()
-	var err error
+	var (
+		err error
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+	)
 	for _, transport := range transports {
-		if closer, isCloser := transport.(io.Closer); isCloser {
-			monitor.Start("close server/", transport.Type(), "[", transport.Tag(), "]")
-			err = E.Append(err, closer.Close(), func(err error) error {
-				return E.Cause(err, "close server/", transport.Type(), "[", transport.Tag(), "]")
-			})
-			monitor.Finish()
+		closer, ok := transport.(io.Closer)
+		if !ok {
+			continue
 		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			monitor := taskmonitor.New(m.logger, C.StopTimeout)
+			monitor.Start("close server/", transport.Type(), "[", transport.Tag(), "]")
+			closeErr := closer.Close()
+			monitor.Finish()
+			if closeErr != nil {
+				mu.Lock()
+				defer mu.Unlock()
+				err = E.Append(err, closeErr, func(err error) error {
+					return E.Cause(err, "close server/", transport.Type(), "[", transport.Tag(), "]")
+				})
+			}
+		}()
 	}
-	return nil
+	wg.Wait()
+	return err
 }
 
 func (m *TransportManager) Transports() []adapter.DNSTransport {


### PR DESCRIPTION
DNS transport queries could block indefinitely during dialing or IO, leading to total resolution failure and shutdown deadlocks. This is common on Linux during transient network failures at startup (e.g. missing default interface) or after system sleep/wake.

- Use context.AfterFunc + SetDeadline to interrupt blocked IO.
- Asynchronize Connector dialing to ensure immediate return on cancellation
  without leaking connections or blocking the connection pool.
- Refactor BaseTransport drainage logic with an on-demand signal.
- Close DNS transports concurrently in TransportManager.
- Add joinedContext helper to link transport and request lifecycles.
- Add unit tests for Connector robustness and resource cleanup.