### PR TITLE
fix(group): prevent nil pointer panic in Selector on reconnect

### DIFF
--- a/protocol/group/selector.go
+++ b/protocol/group/selector.go
@@ -141,7 +141,11 @@ func (s *Selector) SelectOutbound(tag string) bool {
 }
 
 func (s *Selector) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
-	conn, err := s.selected.Load().DialContext(ctx, network, destination)
+	selected := s.selected.Load()
+	if selected == nil {
+		return nil, E.New("no selected outbound")
+	}
+	conn, err := selected.DialContext(ctx, network, destination)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +153,11 @@ func (s *Selector) DialContext(ctx context.Context, network string, destination 
 }
 
 func (s *Selector) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
-	conn, err := s.selected.Load().ListenPacket(ctx, destination)
+	selected := s.selected.Load()
+	if selected == nil {
+		return nil, E.New("no selected outbound")
+	}
+	conn, err := selected.ListenPacket(ctx, destination)
 	if err != nil {
 		return nil, err
 	}
@@ -159,6 +167,10 @@ func (s *Selector) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 func (s *Selector) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	ctx = interrupt.ContextWithIsExternalConnection(ctx)
 	selected := s.selected.Load()
+	if selected == nil {
+		N.CloseOnHandshakeFailure(conn, onClose, E.New("no selected outbound"))
+		return
+	}
 	if outboundHandler, isHandler := selected.(adapter.ConnectionHandlerEx); isHandler {
 		outboundHandler.NewConnectionEx(ctx, conn, metadata, onClose)
 	} else {
@@ -169,6 +181,10 @@ func (s *Selector) NewConnectionEx(ctx context.Context, conn net.Conn, metadata 
 func (s *Selector) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	ctx = interrupt.ContextWithIsExternalConnection(ctx)
 	selected := s.selected.Load()
+	if selected == nil {
+		N.CloseOnHandshakeFailure(conn, onClose, E.New("no selected outbound"))
+		return
+	}
 	if outboundHandler, isHandler := selected.(adapter.PacketConnectionHandlerEx); isHandler {
 		outboundHandler.NewPacketConnectionEx(ctx, conn, metadata, onClose)
 	} else {
@@ -178,6 +194,9 @@ func (s *Selector) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn,
 
 func (s *Selector) NewDirectRouteConnection(metadata adapter.InboundContext, routeContext tun.DirectRouteContext, timeout time.Duration) (tun.DirectRouteDestination, error) {
 	selected := s.selected.Load()
+	if selected == nil {
+		return nil, E.New("no selected outbound")
+	}
 	if !common.Contains(selected.Network(), metadata.Network) {
 		return nil, E.New(metadata.Network, " is not supported by outbound: ", selected.Tag())
 	}


### PR DESCRIPTION
## Summary

Adds nil checks for `selected.Load()` in Selector's connection methods to prevent nil pointer panic on reconnect.

When a Tailscale endpoint uses a Selector as its detour, restarting sing-box causes a panic at `selector.go:144` because the Tailscale endpoint dials through the Selector before `Start()` populates the `selected` field.

Fixes #3917.

## Changes

Added nil guards in 5 methods that call `s.selected.Load()` without checking:
- `DialContext` — return error
- `ListenPacket` — return error
- `NewConnectionEx` — `CloseOnHandshakeFailure`
- `NewPacketConnectionEx` — `CloseOnHandshakeFailure`
- `NewDirectRouteConnection` — return error

Note: `Network()` and `Now()` already had nil checks — this makes the pattern consistent across all methods.

## Reproduction

```bash
# First run — works fine
sing-box run -c config-with-selector-and-tailscale.json
# Ctrl+C to stop

# Second run — panic
sing-box run -c config-with-selector-and-tailscale.json
# panic: runtime error: invalid memory address or nil pointer dereference
# goroutine N [running]:
# github.com/sagernet/sing-box/protocol/group.(*Selector).DialContext(...)
#     selector.go:144 +0x64
```

Minimal config to reproduce (replace auth_key and server with valid values):

```json
{
    "dns": {
        "servers": [
            {
                "type": "https",
                "tag": "proxy-dns",
                "detour": "proxy",
                "server": "1.1.1.1"
            },
            {
                "type": "tailscale",
                "tag": "ts-dns",
                "endpoint": "tailscale"
            }
        ],
        "rules": [
            {
                "domain_suffix": [
                    "ts.net"
                ],
                "server": "ts-dns"
            }
        ],
        "strategy": "ipv4_only",
        "final": "proxy-dns"
    },
    "inbounds": [
        {
            "type": "tun",
            "tag": "tun-in",
            "address": [
                "172.19.0.1/30"
            ],
            "auto_route": true,
            "route_address": [
                "100.64.0.0/10"
            ],
            "route_exclude_address": [
                "1.2.3.4/32"
            ]
        }
    ],
    "endpoints": [
        {
            "type": "tailscale",
            "tag": "tailscale",
            "detour": "proxy",
            "state_directory": "tailscale",
            "auth_key": "tskey-auth-VALID_KEY",
            "hostname": "test",
            "accept_routes": true,
            "udp_timeout": "5m0s"
        }
    ],
    "outbounds": [
        {
            "type": "selector",
            "tag": "proxy",
            "outbounds": [
                "vless-out"
            ],
            "default": "vless-out"
        },
        {
            "type": "vless",
            "tag": "vless-out",
            "server": "1.2.3.4",
            "server_port": 8443,
            "uuid": "valid-uuid",
            "flow": "xtls-rprx-vision",
            "tls": {
                "enabled": true,
                "server_name": "example.com",
                "utls": {
                    "enabled": true,
                    "fingerprint": "chrome"
                },
                "reality": {
                    "enabled": true,
                    "public_key": "valid",
                    "short_id": "valid"
                }
            }
        },
        {
            "type": "direct",
            "tag": "direct"
        }
    ],
    "route": {
        "default_domain_resolver": "proxy-dns",
        "rules": [
            {
                "action": "sniff"
            },
            {
                "protocol": "dns",
                "action": "hijack-dns"
            },
            {
                "ip_cidr": [
                    "1.2.3.4/32"
                ],
                "outbound": "direct"
            },
            {
                "ip_cidr": [
                    "100.64.0.0/10"
                ],
                "outbound": "tailscale"
            }
        ],
        "final": "proxy"
    }
}
```

## Testing

- Built and tested on macOS (darwin/arm64) with Tailscale endpoint + Selector config
- Original binary: panics on second `sing-box run` after Ctrl+C
- Patched binary: reconnects successfully