### PR TITLE
fix(rpm): add vendor field to fpm config to avoid (none) vendor

### DIFF
--- a/.fpm_systemd
+++ b/.fpm_systemd
@@ -4,6 +4,7 @@
 --license GPL-3.0-or-later
 --description "The universal proxy platform."
 --url "https://sing-box.sagernet.org/"
+--vendor SagerNet
 --maintainer "nekohasekai <contact-git@sekai.icu>"
 --deb-field "Bug: https://github.com/SagerNet/sing-box/issues"
 --no-deb-generate-changes


### PR DESCRIPTION
This PR adds the `--vendor` field to the Ruby fpm configuration .

Generated RPM packages with `Vendor: (none)` causes vendor change warnings in zypper on openSUSE.

After this change, RPM metadata should correctly includes:
```
Vendor: SagerNet
```
This will improve compatibility with openSUSE, which relies on the `Vendor` field for vendor stickiness and package upgrade decisions. This will fix #3962 .
