### PR TITLE
fix: zero naive inbound padding bytes to prevent memory leak

### DIFF
--- a/protocol/naive/inbound_conn.go
+++ b/protocol/naive/inbound_conn.go
@@ -95,7 +95,7 @@ func (p *paddingConn) writeWithPadding(writer io.Writer, data []byte) (n int, er
 		binary.BigEndian.PutUint16(header, uint16(len(data)))
 		header[2] = byte(paddingSize)
 		common.Must1(buffer.Write(data))
-		buffer.Extend(paddingSize)
+		common.Must(buffer.WriteZeroN(paddingSize))
 		_, err = writer.Write(buffer.Bytes())
 		if err == nil {
 			n = len(data)
@@ -117,7 +117,7 @@ func (p *paddingConn) writeBufferWithPadding(writer io.Writer, buffer *buf.Buffe
 		header := buffer.ExtendHeader(3)
 		binary.BigEndian.PutUint16(header, uint16(bufferLen))
 		header[2] = byte(paddingSize)
-		buffer.Extend(paddingSize)
+		common.Must(buffer.WriteZeroN(paddingSize))
 		p.writePadding++
 	}
 	return common.Error(writer.Write(buffer.Bytes()))


### PR DESCRIPTION
This changes the Naive payload padding writes in protocol/naive/inbound_conn.go to zero-fill the extended padding area.

Before:
buffer.Extend(paddingSize)

After:
common.Must(buffer.WriteZeroN(paddingSize))

This makes payload padding match the Naive spec (zeros[padding_size]) and avoids leaking stale pooled-buffer contents in padded DATA frames.