### PR TITLE
route: allow empty string in package_name to match unidentified packages

### DIFF
--- a/route/rule/rule_item_package_name.go
+++ b/route/rule/rule_item_package_name.go
@@ -26,7 +26,7 @@ func NewPackageNameItem(packageNameList []string) *PackageNameItem {
 
 func (r *PackageNameItem) Match(metadata *adapter.InboundContext) bool {
 	if metadata.ProcessInfo == nil || len(metadata.ProcessInfo.AndroidPackageNames) == 0 {
-		return false
+		return r.packageMap[""]
 	}
 	for _, packageName := range metadata.ProcessInfo.AndroidPackageNames {
 		if r.packageMap[packageName] {


### PR DESCRIPTION
Implements Option 1 from #4009.

When an app uses `SO_BINDTODEVICE` to bind to a specific interface, `getConnectionOwnerUid()` fails and `ProcessInfo` remains `nil`. Currently `package_name` rules silently return `false` in this case, with no way for users to match such traffic.

This one-line change checks if an empty string `""` is present in the rule's package map when the package name cannot be determined, instead of always returning `false`. Existing behavior is unchanged when `""` is not in the rule.

Usage:
```
{"package_name": [""], "outbound": "block"}
```