### PR TITLE
Add package_name_regex rule item

### DIFF
--- a/cmd/sing-box/cmd_rule_set_compile.go
+++ b/cmd/sing-box/cmd_rule_set_compile.go
@@ -82,6 +82,11 @@ func compileRuleSet(sourcePath string) error {
 }
 
 func downgradeRuleSetVersion(version uint8, options option.PlainRuleSet) uint8 {
+	if version == C.RuleSetVersion5 && !rule.HasHeadlessRule(options.Rules, func(rule option.DefaultHeadlessRule) bool {
+		return len(rule.PackageNameRegex) > 0
+	}) {
+		version = C.RuleSetVersion4
+	}
 	if version == C.RuleSetVersion4 && !rule.HasHeadlessRule(options.Rules, func(rule option.DefaultHeadlessRule) bool {
 		return rule.NetworkInterfaceAddress != nil && rule.NetworkInterfaceAddress.Size() > 0 ||
 			len(rule.DefaultInterfaceAddress) > 0

--- a/cmd/sing-box/cmd_tools_networkquality.go
+++ b/cmd/sing-box/cmd_tools_networkquality.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sagernet/sing-box/common/networkquality"
+	"github.com/sagernet/sing-box/log"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	commandNetworkQualityFlagConfigURL  string
+	commandNetworkQualityFlagSerial     bool
+	commandNetworkQualityFlagMaxRuntime int
+)
+
+var commandNetworkQuality = &cobra.Command{
+	Use:   "networkquality",
+	Short: "Run a network quality test",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := runNetworkQuality()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	commandNetworkQuality.Flags().StringVar(
+		&commandNetworkQualityFlagConfigURL,
+		"config-url", "",
+		"Network quality test config URL (default: Apple mensura)",
+	)
+	commandNetworkQuality.Flags().BoolVar(
+		&commandNetworkQualityFlagSerial,
+		"serial", false,
+		"Run download and upload tests sequentially instead of in parallel",
+	)
+	commandNetworkQuality.Flags().IntVar(
+		&commandNetworkQualityFlagMaxRuntime,
+		"max-runtime", int(networkquality.DefaultMaxRuntime/time.Second),
+		"Network quality maximum runtime in seconds",
+	)
+	commandTools.AddCommand(commandNetworkQuality)
+}
+
+func runNetworkQuality() error {
+	instance, err := createPreStartedClient()
+	if err != nil {
+		return err
+	}
+	defer instance.Close()
+
+	dialer, err := createDialer(instance, commandToolsFlagOutbound)
+	if err != nil {
+		return err
+	}
+
+	httpClient := networkquality.NewHTTPClient(dialer)
+	defer httpClient.CloseIdleConnections()
+
+	fmt.Fprintln(os.Stderr, "==== NETWORK QUALITY TEST ====")
+
+	result, err := networkquality.Run(networkquality.Options{
+		ConfigURL:  commandNetworkQualityFlagConfigURL,
+		HTTPClient: httpClient,
+		Serial:     commandNetworkQualityFlagSerial,
+		MaxRuntime: time.Duration(commandNetworkQualityFlagMaxRuntime) * time.Second,
+		Context:    globalCtx,
+		OnProgress: func(p networkquality.Progress) {
+			if !commandNetworkQualityFlagSerial && p.Phase != networkquality.PhaseIdle {
+				fmt.Fprintf(os.Stderr, "\rDownload: %s  RPM: %d  Upload: %s  RPM: %d",
+					formatBitrate(p.DownloadCapacity), p.DownloadRPM,
+					formatBitrate(p.UploadCapacity), p.UploadRPM)
+				return
+			}
+			switch networkquality.Phase(p.Phase) {
+			case networkquality.PhaseIdle:
+				if p.IdleLatencyMs > 0 {
+					fmt.Fprintf(os.Stderr, "\rIdle Latency: %d ms", p.IdleLatencyMs)
+				} else {
+					fmt.Fprint(os.Stderr, "\rMeasuring idle latency...")
+				}
+			case networkquality.PhaseDownload:
+				fmt.Fprintf(os.Stderr, "\rDownload: %s  RPM: %d",
+					formatBitrate(p.DownloadCapacity), p.DownloadRPM)
+			case networkquality.PhaseUpload:
+				fmt.Fprintf(os.Stderr, "\rUpload: %s  RPM: %d",
+					formatBitrate(p.UploadCapacity), p.UploadRPM)
+			}
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, strings.Repeat("-", 40))
+	fmt.Fprintf(os.Stderr, "Idle Latency:            %d ms\n", result.IdleLatencyMs)
+	fmt.Fprintf(os.Stderr, "Download Capacity:       %-20s Accuracy: %s\n", formatBitrate(result.DownloadCapacity), result.DownloadCapacityAccuracy)
+	fmt.Fprintf(os.Stderr, "Upload Capacity:         %-20s Accuracy: %s\n", formatBitrate(result.UploadCapacity), result.UploadCapacityAccuracy)
+	fmt.Fprintf(os.Stderr, "Download Responsiveness: %-20s Accuracy: %s\n", fmt.Sprintf("%d RPM", result.DownloadRPM), result.DownloadRPMAccuracy)
+	fmt.Fprintf(os.Stderr, "Upload Responsiveness:   %-20s Accuracy: %s\n", fmt.Sprintf("%d RPM", result.UploadRPM), result.UploadRPMAccuracy)
+	return nil
+}
+
+func formatBitrate(bps int64) string {
+	switch {
+	case bps >= 1_000_000_000:
+		return fmt.Sprintf("%.1f Gbps", float64(bps)/1_000_000_000)
+	case bps >= 1_000_000:
+		return fmt.Sprintf("%.1f Mbps", float64(bps)/1_000_000)
+	case bps >= 1_000:
+		return fmt.Sprintf("%.1f Kbps", float64(bps)/1_000)
+	default:
+		return fmt.Sprintf("%d bps", bps)
+	}
+}

--- a/common/networkquality/http.go
+++ b/common/networkquality/http.go
@@ -1,0 +1,109 @@
+package networkquality
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+
+	C "github.com/sagernet/sing-box/constant"
+	sBufio "github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+// NewHTTPClient creates an http.Client that dials through the given dialer.
+// The dialer should already handle DNS resolution if needed.
+func NewHTTPClient(dialer N.Dialer) *http.Client {
+	transport := &http.Transport{
+		ForceAttemptHTTP2:   true,
+		TLSHandshakeTimeout: C.TCPTimeout,
+	}
+	if dialer != nil {
+		transport.DialContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, M.ParseSocksaddr(addr))
+		}
+	}
+	return &http.Client{Transport: transport}
+}
+
+func baseTransportFromClient(client *http.Client) (*http.Transport, error) {
+	if client == nil {
+		return nil, E.New("http client is nil")
+	}
+	if client.Transport == nil {
+		return http.DefaultTransport.(*http.Transport).Clone(), nil
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		return nil, E.New("http client transport must be *http.Transport")
+	}
+	return transport.Clone(), nil
+}
+
+func newMeasurementClient(
+	baseClient *http.Client,
+	connectEndpoint string,
+	singleConnection bool,
+	disableKeepAlives bool,
+	readCounters []N.CountFunc,
+	writeCounters []N.CountFunc,
+) (*http.Client, error) {
+	transport, err := baseTransportFromClient(baseClient)
+	if err != nil {
+		return nil, err
+	}
+	transport.DisableCompression = true
+	transport.DisableKeepAlives = disableKeepAlives
+	if singleConnection {
+		transport.MaxConnsPerHost = 1
+		transport.MaxIdleConnsPerHost = 1
+		transport.MaxIdleConns = 1
+	}
+
+	baseDialContext := transport.DialContext
+	if baseDialContext == nil {
+		dialer := &net.Dialer{}
+		baseDialContext = dialer.DialContext
+	}
+	connectEndpoint = strings.TrimSpace(connectEndpoint)
+	transport.DialContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		dialAddr := addr
+		if connectEndpoint != "" {
+			dialAddr = rewriteDialAddress(addr, connectEndpoint)
+		}
+		conn, dialErr := baseDialContext(ctx, network, dialAddr)
+		if dialErr != nil {
+			return nil, dialErr
+		}
+		if len(readCounters) > 0 || len(writeCounters) > 0 {
+			return sBufio.NewCounterConn(conn, readCounters, writeCounters), nil
+		}
+		return conn, nil
+	}
+
+	return &http.Client{
+		Transport:     transport,
+		CheckRedirect: baseClient.CheckRedirect,
+		Jar:           baseClient.Jar,
+		Timeout:       baseClient.Timeout,
+	}, nil
+}
+
+func rewriteDialAddress(addr string, connectEndpoint string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	endpointHost, endpointPort, err := net.SplitHostPort(connectEndpoint)
+	if err == nil {
+		host = endpointHost
+		if endpointPort != "" {
+			port = endpointPort
+		}
+	} else if connectEndpoint != "" {
+		host = connectEndpoint
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/common/networkquality/networkquality.go
+++ b/common/networkquality/networkquality.go
@@ -1,0 +1,1408 @@
+package networkquality
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptrace"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sBufio "github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	N "github.com/sagernet/sing/common/network"
+)
+
+const DefaultConfigURL = "https://mensura.cdn-apple.com/api/v1/gm/config"
+
+type Config struct {
+	Version      int    `json:"version"`
+	TestEndpoint string `json:"test_endpoint"`
+	URLs         URLs   `json:"urls"`
+}
+
+type URLs struct {
+	SmallHTTPSDownloadURL string `json:"small_https_download_url"`
+	LargeHTTPSDownloadURL string `json:"large_https_download_url"`
+	HTTPSUploadURL        string `json:"https_upload_url"`
+	SmallDownloadURL      string `json:"small_download_url"`
+	LargeDownloadURL      string `json:"large_download_url"`
+	UploadURL             string `json:"upload_url"`
+}
+
+func (u *URLs) smallDownloadURL() string {
+	if u.SmallHTTPSDownloadURL != "" {
+		return u.SmallHTTPSDownloadURL
+	}
+	return u.SmallDownloadURL
+}
+
+func (u *URLs) largeDownloadURL() string {
+	if u.LargeHTTPSDownloadURL != "" {
+		return u.LargeHTTPSDownloadURL
+	}
+	return u.LargeDownloadURL
+}
+
+func (u *URLs) uploadURL() string {
+	if u.HTTPSUploadURL != "" {
+		return u.HTTPSUploadURL
+	}
+	return u.UploadURL
+}
+
+type Accuracy int32
+
+const (
+	AccuracyLow    Accuracy = 0
+	AccuracyMedium Accuracy = 1
+	AccuracyHigh   Accuracy = 2
+)
+
+func (a Accuracy) String() string {
+	switch a {
+	case AccuracyHigh:
+		return "High"
+	case AccuracyMedium:
+		return "Medium"
+	default:
+		return "Low"
+	}
+}
+
+type Result struct {
+	DownloadCapacity         int64
+	UploadCapacity           int64
+	DownloadRPM              int32
+	UploadRPM                int32
+	IdleLatencyMs            int32
+	DownloadCapacityAccuracy Accuracy
+	UploadCapacityAccuracy   Accuracy
+	DownloadRPMAccuracy      Accuracy
+	UploadRPMAccuracy        Accuracy
+}
+
+type Progress struct {
+	Phase                    Phase
+	DownloadCapacity         int64
+	UploadCapacity           int64
+	DownloadRPM              int32
+	UploadRPM                int32
+	IdleLatencyMs            int32
+	ElapsedMs                int64
+	DownloadCapacityAccuracy Accuracy
+	UploadCapacityAccuracy   Accuracy
+	DownloadRPMAccuracy      Accuracy
+	UploadRPMAccuracy        Accuracy
+}
+
+type Phase int32
+
+const (
+	PhaseIdle     Phase = 0
+	PhaseDownload Phase = 1
+	PhaseUpload   Phase = 2
+	PhaseDone     Phase = 3
+)
+
+type Options struct {
+	ConfigURL  string
+	HTTPClient *http.Client
+	Serial     bool
+	MaxRuntime time.Duration
+	OnProgress func(Progress)
+	Context    context.Context
+}
+
+const DefaultMaxRuntime = 20 * time.Second
+
+type measurementSettings struct {
+	idleProbeCount      int
+	testTimeout         time.Duration
+	stabilityInterval   time.Duration
+	sampleInterval      time.Duration
+	progressInterval    time.Duration
+	baseProbeInterval   time.Duration
+	initialConnections  int
+	maxConnections      int
+	movingAvgDistance   int
+	trimPercent         int
+	stdDevTolerancePct  float64
+	maxProbeCapacityPct float64
+	uploadRequestSize   int64
+}
+
+var settings = measurementSettings{
+	idleProbeCount:      5,
+	testTimeout:         DefaultMaxRuntime,
+	stabilityInterval:   time.Second,
+	sampleInterval:      250 * time.Millisecond,
+	progressInterval:    500 * time.Millisecond,
+	baseProbeInterval:   100 * time.Millisecond,
+	initialConnections:  1,
+	maxConnections:      16,
+	movingAvgDistance:   4,
+	trimPercent:         5,
+	stdDevTolerancePct:  5,
+	maxProbeCapacityPct: 0.05,
+	uploadRequestSize:   4 << 20,
+}
+
+type resolvedConfig struct {
+	smallURL        *url.URL
+	largeURL        *url.URL
+	uploadURL       *url.URL
+	connectEndpoint string
+}
+
+type directionPlan struct {
+	dataURL         *url.URL
+	probeURL        *url.URL
+	connectEndpoint string
+	isUpload        bool
+}
+
+type probeTrace struct {
+	reused            bool
+	connectStart      time.Time
+	connectDone       time.Time
+	tlsStart          time.Time
+	tlsDone           time.Time
+	gotConn           time.Time
+	wroteRequest      time.Time
+	firstResponseByte time.Time
+}
+
+type probeMeasurement struct {
+	total      time.Duration
+	tcp        time.Duration
+	tls        time.Duration
+	httpFirst  time.Duration
+	httpLoaded time.Duration
+	bytes      int64
+	reused     bool
+}
+
+type probeRound struct {
+	interval   int
+	tcp        time.Duration
+	tls        time.Duration
+	httpFirst  time.Duration
+	httpLoaded time.Duration
+}
+
+func (p probeRound) responsivenessLatency() float64 {
+	var foreignSamples []float64
+	if p.tcp > 0 {
+		foreignSamples = append(foreignSamples, durationMillis(p.tcp))
+	}
+	if p.tls > 0 {
+		foreignSamples = append(foreignSamples, durationMillis(p.tls))
+	}
+	if p.httpFirst > 0 {
+		foreignSamples = append(foreignSamples, durationMillis(p.httpFirst))
+	}
+	if len(foreignSamples) == 0 || p.httpLoaded <= 0 {
+		return 0
+	}
+	return (meanFloat64s(foreignSamples) + durationMillis(p.httpLoaded)) / 2
+}
+
+const maxConsecutiveErrors = 3
+
+type loadConnection struct {
+	client   *http.Client
+	dataURL  *url.URL
+	isUpload bool
+	active   atomic.Bool
+	ready    atomic.Bool
+}
+
+func (c *loadConnection) run(ctx context.Context, onError func(error)) {
+	defer c.client.CloseIdleConnections()
+	markActive := func() {
+		c.ready.Store(true)
+		c.active.Store(true)
+	}
+	var consecutiveErrors int
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		var err error
+		if c.isUpload {
+			err = runUploadRequest(ctx, c.client, c.dataURL.String(), markActive)
+		} else {
+			err = runDownloadRequest(ctx, c.client, c.dataURL.String(), markActive)
+		}
+		c.active.Store(false)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			consecutiveErrors++
+			if consecutiveErrors > maxConsecutiveErrors {
+				onError(err)
+				return
+			}
+			c.client.CloseIdleConnections()
+			continue
+		}
+		consecutiveErrors = 0
+	}
+}
+
+type intervalThroughput struct {
+	interval int
+	bps      float64
+}
+
+type intervalWindow struct {
+	lower int
+	upper int
+}
+
+type stabilityTracker struct {
+	window             int
+	trimPercent        int
+	stdDevTolerancePct float64
+	instantaneous      []float64
+	movingAverages     []float64
+}
+
+func (s *stabilityTracker) add(value float64) bool {
+	if value <= 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return false
+	}
+	s.instantaneous = append(s.instantaneous, value)
+	if len(s.instantaneous) > s.window {
+		s.instantaneous = s.instantaneous[len(s.instantaneous)-s.window:]
+	}
+	s.movingAverages = append(s.movingAverages, meanFloat64s(s.instantaneous))
+	if len(s.movingAverages) > s.window {
+		s.movingAverages = s.movingAverages[len(s.movingAverages)-s.window:]
+	}
+	return s.stable()
+}
+
+func (s *stabilityTracker) ready() bool {
+	return len(s.movingAverages) >= s.window
+}
+
+func (s *stabilityTracker) accuracy() Accuracy {
+	if s.stable() {
+		return AccuracyHigh
+	}
+	if s.ready() {
+		return AccuracyMedium
+	}
+	return AccuracyLow
+}
+
+func (s *stabilityTracker) stable() bool {
+	if len(s.movingAverages) < s.window {
+		return false
+	}
+	trimmed := upperTrimFloat64s(s.movingAverages, s.trimPercent)
+	if len(trimmed) == 0 {
+		return false
+	}
+	mean := meanFloat64s(trimmed)
+	if mean <= 0 {
+		return false
+	}
+	return stdDevFloat64s(trimmed) <= mean*(s.stdDevTolerancePct/100)
+}
+
+type directionMeasurement struct {
+	capacity         int64
+	rpm              int32
+	capacityAccuracy Accuracy
+	rpmAccuracy      Accuracy
+}
+
+type directionRunner struct {
+	baseClient *http.Client
+	plan       directionPlan
+	probeBytes int64
+
+	errCh   chan error
+	errOnce sync.Once
+	wg      sync.WaitGroup
+
+	totalBytes      atomic.Int64
+	currentCapacity atomic.Int64
+	currentRPM      atomic.Int32
+	currentInterval atomic.Int64
+
+	connMu         sync.Mutex
+	connections    []*loadConnection
+	nextConnection int
+
+	probeMu              sync.Mutex
+	probeRounds          []probeRound
+	intervalProbeValues  []float64
+	responsivenessWindow *intervalWindow
+	throughputs          []intervalThroughput
+	throughputWindow     *intervalWindow
+}
+
+func newDirectionRunner(baseClient *http.Client, plan directionPlan, probeBytes int64) *directionRunner {
+	return &directionRunner{
+		baseClient: baseClient,
+		plan:       plan,
+		probeBytes: probeBytes,
+		errCh:      make(chan error, 1),
+	}
+}
+
+func (r *directionRunner) fail(err error) {
+	if err == nil {
+		return
+	}
+	r.errOnce.Do(func() {
+		select {
+		case r.errCh <- err:
+		default:
+		}
+	})
+}
+
+func (r *directionRunner) onConnectionFailed(err error) {
+	r.connMu.Lock()
+	activeCount := 0
+	for _, conn := range r.connections {
+		if conn.active.Load() {
+			activeCount++
+		}
+	}
+	r.connMu.Unlock()
+	if activeCount == 0 {
+		r.fail(err)
+	}
+}
+
+func (r *directionRunner) addConnection(ctx context.Context) error {
+	counter := N.CountFunc(func(n int64) { r.totalBytes.Add(n) })
+	var readCounters, writeCounters []N.CountFunc
+	if r.plan.isUpload {
+		writeCounters = []N.CountFunc{counter}
+	} else {
+		readCounters = []N.CountFunc{counter}
+	}
+	client, err := newMeasurementClient(r.baseClient, r.plan.connectEndpoint, true, false, readCounters, writeCounters)
+	if err != nil {
+		return err
+	}
+	conn := &loadConnection{
+		client:   client,
+		dataURL:  r.plan.dataURL,
+		isUpload: r.plan.isUpload,
+	}
+	r.connMu.Lock()
+	r.connections = append(r.connections, conn)
+	r.connMu.Unlock()
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		conn.run(ctx, r.onConnectionFailed)
+	}()
+	return nil
+}
+
+func (r *directionRunner) connectionCount() int {
+	r.connMu.Lock()
+	defer r.connMu.Unlock()
+	return len(r.connections)
+}
+
+func (r *directionRunner) pickReadyConnection() *loadConnection {
+	r.connMu.Lock()
+	defer r.connMu.Unlock()
+	if len(r.connections) == 0 {
+		return nil
+	}
+	for i := 0; i < len(r.connections); i++ {
+		index := (r.nextConnection + i) % len(r.connections)
+		if r.connections[index].ready.Load() && r.connections[index].active.Load() {
+			r.nextConnection = (index + 1) % len(r.connections)
+			return r.connections[index]
+		}
+	}
+	return nil
+}
+
+func (r *directionRunner) startProber(ctx context.Context) {
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		timer := time.NewTimer(0)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+			}
+			conn := r.pickReadyConnection()
+			if conn != nil {
+				foreignClient, err := newMeasurementClient(r.baseClient, r.plan.connectEndpoint, true, true, nil, nil)
+				if err != nil {
+					r.fail(err)
+					return
+				}
+				round, err := collectProbeRound(ctx, foreignClient, conn.client, r.plan.probeURL.String())
+				foreignClient.CloseIdleConnections()
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					r.fail(err)
+					return
+				}
+				r.recordProbeRound(probeRound{
+					interval:   int(r.currentInterval.Load()),
+					tcp:        round.tcp,
+					tls:        round.tls,
+					httpFirst:  round.httpFirst,
+					httpLoaded: round.httpLoaded,
+				})
+			}
+			timer.Reset(r.currentProbeInterval())
+		}
+	}()
+}
+
+func (r *directionRunner) currentProbeInterval() time.Duration {
+	interval := settings.baseProbeInterval
+	capacity := r.currentCapacity.Load()
+	if capacity <= 0 || r.probeBytes <= 0 || settings.maxProbeCapacityPct <= 0 {
+		return interval
+	}
+	bitsPerRound := float64(r.probeBytes*2) * 8
+	minSeconds := bitsPerRound / (float64(capacity) * settings.maxProbeCapacityPct)
+	if minSeconds <= 0 {
+		return interval
+	}
+	capacityInterval := time.Duration(minSeconds * float64(time.Second))
+	if capacityInterval > interval {
+		interval = capacityInterval
+	}
+	if interval > settings.stabilityInterval {
+		interval = settings.stabilityInterval
+	}
+	return interval
+}
+
+func (r *directionRunner) recordProbeRound(round probeRound) {
+	r.probeMu.Lock()
+	r.probeRounds = append(r.probeRounds, round)
+	if latency := round.responsivenessLatency(); latency > 0 {
+		r.intervalProbeValues = append(r.intervalProbeValues, latency)
+	}
+	r.currentRPM.Store(calculateRPM(r.probeRounds))
+	r.probeMu.Unlock()
+}
+
+func (r *directionRunner) swapIntervalProbeValues() []float64 {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	values := append([]float64(nil), r.intervalProbeValues...)
+	r.intervalProbeValues = nil
+	return values
+}
+
+func (r *directionRunner) setResponsivenessWindow(currentInterval int) {
+	lower := currentInterval - settings.movingAvgDistance + 1
+	if lower < 0 {
+		lower = 0
+	}
+	r.probeMu.Lock()
+	r.responsivenessWindow = &intervalWindow{lower: lower, upper: currentInterval}
+	r.probeMu.Unlock()
+}
+
+func (r *directionRunner) recordThroughput(interval int, bps float64) {
+	r.probeMu.Lock()
+	r.throughputs = append(r.throughputs, intervalThroughput{interval: interval, bps: bps})
+	r.probeMu.Unlock()
+}
+
+func (r *directionRunner) setThroughputWindow(currentInterval int) {
+	lower := currentInterval - settings.movingAvgDistance + 1
+	if lower < 0 {
+		lower = 0
+	}
+	r.probeMu.Lock()
+	r.throughputWindow = &intervalWindow{lower: lower, upper: currentInterval}
+	r.probeMu.Unlock()
+}
+
+func (r *directionRunner) finalRPM() int32 {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	if r.responsivenessWindow == nil {
+		return calculateRPM(r.probeRounds)
+	}
+	var rounds []probeRound
+	for _, round := range r.probeRounds {
+		if round.interval >= r.responsivenessWindow.lower && round.interval <= r.responsivenessWindow.upper {
+			rounds = append(rounds, round)
+		}
+	}
+	if len(rounds) == 0 {
+		rounds = r.probeRounds
+	}
+	return calculateRPM(rounds)
+}
+
+func (r *directionRunner) finalCapacity(totalDuration time.Duration) int64 {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	var samples []float64
+	if r.throughputWindow != nil {
+		for _, sample := range r.throughputs {
+			if sample.interval >= r.throughputWindow.lower && sample.interval <= r.throughputWindow.upper {
+				samples = append(samples, sample.bps)
+			}
+		}
+	}
+	if len(samples) == 0 {
+		for _, sample := range r.throughputs {
+			samples = append(samples, sample.bps)
+		}
+	}
+	if len(samples) > 0 {
+		return int64(math.Round(upperTrimmedMean(samples, settings.trimPercent)))
+	}
+	if totalDuration > 0 {
+		return int64(float64(r.totalBytes.Load()) * 8 / totalDuration.Seconds())
+	}
+	return 0
+}
+
+func (r *directionRunner) wait() {
+	r.wg.Wait()
+}
+
+func Run(options Options) (*Result, error) {
+	ctx := options.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if options.HTTPClient == nil {
+		return nil, E.New("http client is required")
+	}
+	maxRuntime, err := normalizeMaxRuntime(options.MaxRuntime)
+	if err != nil {
+		return nil, err
+	}
+	configURL := resolveConfigURL(options.ConfigURL)
+	config, err := fetchConfig(ctx, options.HTTPClient, configURL)
+	if err != nil {
+		return nil, E.Cause(err, "fetch config")
+	}
+	resolved, err := validateConfig(config)
+	if err != nil {
+		return nil, E.Cause(err, "validate config")
+	}
+
+	start := time.Now()
+	report := func(progress Progress) {
+		if options.OnProgress == nil {
+			return
+		}
+		progress.ElapsedMs = time.Since(start).Milliseconds()
+		options.OnProgress(progress)
+	}
+
+	report(Progress{Phase: PhaseIdle})
+	idleLatency, probeBytes, err := measureIdleLatency(ctx, options.HTTPClient, resolved)
+	if err != nil {
+		return nil, E.Cause(err, "measure idle latency")
+	}
+	report(Progress{Phase: PhaseIdle, IdleLatencyMs: idleLatency})
+
+	var download, upload *directionMeasurement
+	if options.Serial {
+		download, upload, err = measureSerial(
+			ctx,
+			options.HTTPClient,
+			resolved,
+			idleLatency,
+			probeBytes,
+			maxRuntime,
+			report,
+		)
+	} else {
+		download, upload, err = measureParallel(
+			ctx,
+			options.HTTPClient,
+			resolved,
+			idleLatency,
+			probeBytes,
+			maxRuntime,
+			report,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		DownloadCapacity:         download.capacity,
+		UploadCapacity:           upload.capacity,
+		DownloadRPM:              download.rpm,
+		UploadRPM:                upload.rpm,
+		IdleLatencyMs:            idleLatency,
+		DownloadCapacityAccuracy: download.capacityAccuracy,
+		UploadCapacityAccuracy:   upload.capacityAccuracy,
+		DownloadRPMAccuracy:      download.rpmAccuracy,
+		UploadRPMAccuracy:        upload.rpmAccuracy,
+	}
+	report(Progress{
+		Phase:                    PhaseDone,
+		DownloadCapacity:         result.DownloadCapacity,
+		UploadCapacity:           result.UploadCapacity,
+		DownloadRPM:              result.DownloadRPM,
+		UploadRPM:                result.UploadRPM,
+		IdleLatencyMs:            result.IdleLatencyMs,
+		DownloadCapacityAccuracy: result.DownloadCapacityAccuracy,
+		UploadCapacityAccuracy:   result.UploadCapacityAccuracy,
+		DownloadRPMAccuracy:      result.DownloadRPMAccuracy,
+		UploadRPMAccuracy:        result.UploadRPMAccuracy,
+	})
+	return result, nil
+}
+
+func normalizeMaxRuntime(maxRuntime time.Duration) (time.Duration, error) {
+	if maxRuntime == 0 {
+		return settings.testTimeout, nil
+	}
+	if maxRuntime < 0 {
+		return 0, E.New("max runtime must be positive")
+	}
+	return maxRuntime, nil
+}
+
+func measureSerial(
+	ctx context.Context,
+	client *http.Client,
+	resolved *resolvedConfig,
+	idleLatency int32,
+	probeBytes int64,
+	maxRuntime time.Duration,
+	report func(Progress),
+) (*directionMeasurement, *directionMeasurement, error) {
+	downloadRuntime, uploadRuntime := splitRuntimeBudget(maxRuntime, 2)
+	report(Progress{Phase: PhaseDownload, IdleLatencyMs: idleLatency})
+	download, err := measureDirection(ctx, client, directionPlan{
+		dataURL:         resolved.largeURL,
+		probeURL:        resolved.smallURL,
+		connectEndpoint: resolved.connectEndpoint,
+	}, probeBytes, downloadRuntime, func(capacity int64, rpm int32) {
+		report(Progress{
+			Phase:            PhaseDownload,
+			DownloadCapacity: capacity,
+			DownloadRPM:      rpm,
+			IdleLatencyMs:    idleLatency,
+		})
+	})
+	if err != nil {
+		return nil, nil, E.Cause(err, "measure download")
+	}
+
+	report(Progress{
+		Phase:            PhaseUpload,
+		DownloadCapacity: download.capacity,
+		DownloadRPM:      download.rpm,
+		IdleLatencyMs:    idleLatency,
+	})
+	upload, err := measureDirection(ctx, client, directionPlan{
+		dataURL:         resolved.uploadURL,
+		probeURL:        resolved.smallURL,
+		connectEndpoint: resolved.connectEndpoint,
+		isUpload:        true,
+	}, probeBytes, uploadRuntime, func(capacity int64, rpm int32) {
+		report(Progress{
+			Phase:            PhaseUpload,
+			DownloadCapacity: download.capacity,
+			UploadCapacity:   capacity,
+			DownloadRPM:      download.rpm,
+			UploadRPM:        rpm,
+			IdleLatencyMs:    idleLatency,
+		})
+	})
+	if err != nil {
+		return nil, nil, E.Cause(err, "measure upload")
+	}
+	return download, upload, nil
+}
+
+func measureParallel(
+	ctx context.Context,
+	client *http.Client,
+	resolved *resolvedConfig,
+	idleLatency int32,
+	probeBytes int64,
+	maxRuntime time.Duration,
+	report func(Progress),
+) (*directionMeasurement, *directionMeasurement, error) {
+	type parallelResult struct {
+		measurement *directionMeasurement
+		err         error
+	}
+	type progressState struct {
+		sync.Mutex
+		downloadCapacity int64
+		uploadCapacity   int64
+		downloadRPM      int32
+		uploadRPM        int32
+	}
+
+	parallelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	report(Progress{Phase: PhaseDownload, IdleLatencyMs: idleLatency})
+	report(Progress{Phase: PhaseUpload, IdleLatencyMs: idleLatency})
+
+	var state progressState
+	sendProgress := func(phase Phase, capacity int64, rpm int32) {
+		state.Lock()
+		if phase == PhaseDownload {
+			state.downloadCapacity = capacity
+			state.downloadRPM = rpm
+		} else {
+			state.uploadCapacity = capacity
+			state.uploadRPM = rpm
+		}
+		snapshot := Progress{
+			Phase:            phase,
+			DownloadCapacity: state.downloadCapacity,
+			UploadCapacity:   state.uploadCapacity,
+			DownloadRPM:      state.downloadRPM,
+			UploadRPM:        state.uploadRPM,
+			IdleLatencyMs:    idleLatency,
+		}
+		state.Unlock()
+		report(snapshot)
+	}
+
+	var wg sync.WaitGroup
+	downloadCh := make(chan parallelResult, 1)
+	uploadCh := make(chan parallelResult, 1)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		measurement, err := measureDirection(parallelCtx, client, directionPlan{
+			dataURL:         resolved.largeURL,
+			probeURL:        resolved.smallURL,
+			connectEndpoint: resolved.connectEndpoint,
+		}, probeBytes, maxRuntime, func(capacity int64, rpm int32) {
+			sendProgress(PhaseDownload, capacity, rpm)
+		})
+		if err != nil {
+			cancel()
+			downloadCh <- parallelResult{err: E.Cause(err, "measure download")}
+			return
+		}
+		downloadCh <- parallelResult{measurement: measurement}
+	}()
+	go func() {
+		defer wg.Done()
+		measurement, err := measureDirection(parallelCtx, client, directionPlan{
+			dataURL:         resolved.uploadURL,
+			probeURL:        resolved.smallURL,
+			connectEndpoint: resolved.connectEndpoint,
+			isUpload:        true,
+		}, probeBytes, maxRuntime, func(capacity int64, rpm int32) {
+			sendProgress(PhaseUpload, capacity, rpm)
+		})
+		if err != nil {
+			cancel()
+			uploadCh <- parallelResult{err: E.Cause(err, "measure upload")}
+			return
+		}
+		uploadCh <- parallelResult{measurement: measurement}
+	}()
+
+	download := <-downloadCh
+	upload := <-uploadCh
+	wg.Wait()
+	if download.err != nil {
+		return nil, nil, download.err
+	}
+	if upload.err != nil {
+		return nil, nil, upload.err
+	}
+	return download.measurement, upload.measurement, nil
+}
+
+func resolveConfigURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return DefaultConfigURL
+	}
+	if !strings.Contains(rawURL, "://") && !strings.Contains(rawURL, "/") {
+		return "https://" + rawURL + "/.well-known/nq"
+	}
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if parsedURL.Scheme != "" && parsedURL.Host != "" && (parsedURL.Path == "" || parsedURL.Path == "/") {
+		parsedURL.Path = "/.well-known/nq"
+		return parsedURL.String()
+	}
+	return rawURL
+}
+
+func fetchConfig(ctx context.Context, client *http.Client, configURL string) (*Config, error) {
+	req, err := newRequest(ctx, http.MethodGet, configURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err = validateResponse(resp); err != nil {
+		return nil, err
+	}
+	var config Config
+	if err = json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return nil, E.Cause(err, "decode config")
+	}
+	return &config, nil
+}
+
+func validateConfig(config *Config) (*resolvedConfig, error) {
+	if config == nil {
+		return nil, E.New("config is nil")
+	}
+	if config.Version != 1 {
+		return nil, E.New("unsupported config version: ", config.Version)
+	}
+	parseURL := func(name string, rawURL string) (*url.URL, error) {
+		if rawURL == "" {
+			return nil, E.New("config missing required URL: ", name)
+		}
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return nil, E.Cause(err, "parse "+name)
+		}
+		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+			return nil, E.New("unsupported URL scheme in ", name, ": ", parsedURL.Scheme)
+		}
+		if parsedURL.Host == "" {
+			return nil, E.New("config missing host in ", name)
+		}
+		return parsedURL, nil
+	}
+
+	smallURL, err := parseURL("small_download_url", config.URLs.smallDownloadURL())
+	if err != nil {
+		return nil, err
+	}
+	largeURL, err := parseURL("large_download_url", config.URLs.largeDownloadURL())
+	if err != nil {
+		return nil, err
+	}
+	uploadURL, err := parseURL("upload_url", config.URLs.uploadURL())
+	if err != nil {
+		return nil, err
+	}
+
+	if smallURL.Host != largeURL.Host || smallURL.Host != uploadURL.Host {
+		return nil, E.New("config URLs must use the same host")
+	}
+
+	return &resolvedConfig{
+		smallURL:        smallURL,
+		largeURL:        largeURL,
+		uploadURL:       uploadURL,
+		connectEndpoint: strings.TrimSpace(config.TestEndpoint),
+	}, nil
+}
+
+func measureIdleLatency(ctx context.Context, baseClient *http.Client, config *resolvedConfig) (int32, int64, error) {
+	var latencies []int64
+	var maxProbeBytes int64
+	for i := 0; i < settings.idleProbeCount; i++ {
+		select {
+		case <-ctx.Done():
+			return 0, 0, ctx.Err()
+		default:
+		}
+		client, err := newMeasurementClient(baseClient, config.connectEndpoint, true, true, nil, nil)
+		if err != nil {
+			return 0, 0, err
+		}
+		measurement, err := runProbe(ctx, client, config.smallURL.String(), false)
+		client.CloseIdleConnections()
+		if err != nil {
+			return 0, 0, err
+		}
+		latencies = append(latencies, measurement.total.Milliseconds())
+		if measurement.bytes > maxProbeBytes {
+			maxProbeBytes = measurement.bytes
+		}
+	}
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	return int32(latencies[len(latencies)/2]), maxProbeBytes, nil
+}
+
+func measureDirection(
+	ctx context.Context,
+	baseClient *http.Client,
+	plan directionPlan,
+	probeBytes int64,
+	maxRuntime time.Duration,
+	onProgress func(capacity int64, rpm int32),
+) (*directionMeasurement, error) {
+	phaseCtx, phaseCancel := context.WithTimeout(ctx, maxRuntime)
+	defer phaseCancel()
+
+	runner := newDirectionRunner(baseClient, plan, probeBytes)
+	defer runner.wait()
+
+	for i := 0; i < settings.initialConnections; i++ {
+		err := runner.addConnection(phaseCtx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	throughputTracker := stabilityTracker{
+		window:             settings.movingAvgDistance,
+		trimPercent:        settings.trimPercent,
+		stdDevTolerancePct: settings.stdDevTolerancePct,
+	}
+	responsivenessTracker := stabilityTracker{
+		window:             settings.movingAvgDistance,
+		trimPercent:        settings.trimPercent,
+		stdDevTolerancePct: settings.stdDevTolerancePct,
+	}
+
+	start := time.Now()
+	sampleTicker := time.NewTicker(settings.sampleInterval)
+	defer sampleTicker.Stop()
+	intervalTicker := time.NewTicker(settings.stabilityInterval)
+	defer intervalTicker.Stop()
+	progressTicker := time.NewTicker(settings.progressInterval)
+	defer progressTicker.Stop()
+
+	prevSampleBytes := int64(0)
+	prevSampleTime := start
+	prevIntervalBytes := int64(0)
+	prevIntervalTime := start
+	var ewmaCapacity float64
+	var proberStarted bool
+	var intervalIndex int
+
+	for {
+		select {
+		case err := <-runner.errCh:
+			return nil, err
+		case now := <-sampleTicker.C:
+			currentBytes := runner.totalBytes.Load()
+			elapsed := now.Sub(prevSampleTime).Seconds()
+			if elapsed > 0 {
+				instantaneousBps := float64(currentBytes-prevSampleBytes) * 8 / elapsed
+				if ewmaCapacity == 0 {
+					ewmaCapacity = instantaneousBps
+				} else {
+					ewmaCapacity = 0.3*instantaneousBps + 0.7*ewmaCapacity
+				}
+				runner.currentCapacity.Store(int64(ewmaCapacity))
+			}
+			prevSampleBytes = currentBytes
+			prevSampleTime = now
+		case <-intervalTicker.C:
+			now := time.Now()
+			currentBytes := runner.totalBytes.Load()
+			elapsed := now.Sub(prevIntervalTime).Seconds()
+			if elapsed > 0 {
+				intervalBps := float64(currentBytes-prevIntervalBytes) * 8 / elapsed
+				runner.recordThroughput(intervalIndex, intervalBps)
+				throughputStable := throughputTracker.add(intervalBps)
+				if throughputStable && runner.throughputWindow == nil {
+					runner.setThroughputWindow(intervalIndex)
+				}
+				if !proberStarted && (throughputStable || (runner.connectionCount() >= settings.maxConnections && throughputTracker.ready())) {
+					proberStarted = true
+					runner.startProber(phaseCtx)
+				}
+				if runner.connectionCount() < settings.maxConnections && runner.throughputWindow == nil {
+					err := runner.addConnection(phaseCtx)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+			if proberStarted {
+				if values := runner.swapIntervalProbeValues(); len(values) > 0 {
+					if responsivenessTracker.add(upperTrimmedMean(values, settings.trimPercent)) && runner.responsivenessWindow == nil {
+						runner.setResponsivenessWindow(intervalIndex)
+						phaseCancel()
+					}
+				}
+			}
+			prevIntervalBytes = currentBytes
+			prevIntervalTime = now
+			intervalIndex++
+			runner.currentInterval.Store(int64(intervalIndex))
+		case <-progressTicker.C:
+			if onProgress != nil {
+				onProgress(int64(ewmaCapacity), runner.currentRPM.Load())
+			}
+		case <-phaseCtx.Done():
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			totalDuration := time.Since(start)
+			return &directionMeasurement{
+				capacity:         runner.finalCapacity(totalDuration),
+				rpm:              runner.finalRPM(),
+				capacityAccuracy: throughputTracker.accuracy(),
+				rpmAccuracy:      responsivenessTracker.accuracy(),
+			}, nil
+		}
+	}
+}
+
+func splitRuntimeBudget(total time.Duration, directions int) (time.Duration, time.Duration) {
+	if directions <= 1 {
+		return total, total
+	}
+	first := total / time.Duration(directions)
+	second := total - first
+	return first, second
+}
+
+func collectProbeRound(ctx context.Context, foreignClient *http.Client, selfClient *http.Client, rawURL string) (probeMeasurement, error) {
+	var foreignResult probeMeasurement
+	var selfResult probeMeasurement
+	var foreignErr error
+	var selfErr error
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		foreignResult, foreignErr = runProbe(ctx, foreignClient, rawURL, false)
+	}()
+	go func() {
+		defer wg.Done()
+		selfResult, selfErr = runProbe(ctx, selfClient, rawURL, true)
+	}()
+	wg.Wait()
+
+	if foreignErr != nil {
+		return probeMeasurement{}, E.Cause(foreignErr, "foreign probe")
+	}
+	if selfErr != nil {
+		return probeMeasurement{}, E.Cause(selfErr, "self probe")
+	}
+	return probeMeasurement{
+		tcp:        foreignResult.tcp,
+		tls:        foreignResult.tls,
+		httpFirst:  foreignResult.httpFirst,
+		httpLoaded: selfResult.httpLoaded,
+	}, nil
+}
+
+func runProbe(ctx context.Context, client *http.Client, rawURL string, expectReuse bool) (probeMeasurement, error) {
+	var trace probeTrace
+	start := time.Now()
+	req, err := newRequest(httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		ConnectStart: func(string, string) {
+			if trace.connectStart.IsZero() {
+				trace.connectStart = time.Now()
+			}
+		},
+		ConnectDone: func(string, string, error) {
+			if trace.connectDone.IsZero() {
+				trace.connectDone = time.Now()
+			}
+		},
+		TLSHandshakeStart: func() {
+			if trace.tlsStart.IsZero() {
+				trace.tlsStart = time.Now()
+			}
+		},
+		TLSHandshakeDone: func(tls.ConnectionState, error) {
+			if trace.tlsDone.IsZero() {
+				trace.tlsDone = time.Now()
+			}
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			trace.reused = info.Reused
+			trace.gotConn = time.Now()
+		},
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			trace.wroteRequest = time.Now()
+		},
+		GotFirstResponseByte: func() {
+			trace.firstResponseByte = time.Now()
+		},
+	}), http.MethodGet, rawURL, nil)
+	if err != nil {
+		return probeMeasurement{}, err
+	}
+	if !expectReuse {
+		req.Close = true
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return probeMeasurement{}, err
+	}
+	defer resp.Body.Close()
+	if err = validateResponse(resp); err != nil {
+		return probeMeasurement{}, err
+	}
+	n, err := io.Copy(io.Discard, resp.Body)
+	end := time.Now()
+	if err != nil {
+		return probeMeasurement{}, err
+	}
+	if expectReuse && !trace.reused {
+		return probeMeasurement{}, E.New("self probe did not reuse an existing connection")
+	}
+
+	httpStart := trace.wroteRequest
+	if httpStart.IsZero() {
+		switch {
+		case !trace.tlsDone.IsZero():
+			httpStart = trace.tlsDone
+		case !trace.connectDone.IsZero():
+			httpStart = trace.connectDone
+		case !trace.gotConn.IsZero():
+			httpStart = trace.gotConn
+		default:
+			httpStart = start
+		}
+	}
+
+	measurement := probeMeasurement{
+		total:  end.Sub(start),
+		bytes:  n,
+		reused: trace.reused,
+	}
+	if !trace.connectStart.IsZero() && !trace.connectDone.IsZero() && trace.connectDone.After(trace.connectStart) {
+		measurement.tcp = trace.connectDone.Sub(trace.connectStart)
+	}
+	if !trace.tlsStart.IsZero() && !trace.tlsDone.IsZero() && trace.tlsDone.After(trace.tlsStart) {
+		measurement.tls = trace.tlsDone.Sub(trace.tlsStart)
+	}
+	if !trace.firstResponseByte.IsZero() && trace.firstResponseByte.After(httpStart) {
+		measurement.httpFirst = trace.firstResponseByte.Sub(httpStart)
+	}
+	if end.After(httpStart) {
+		measurement.httpLoaded = end.Sub(httpStart)
+	}
+	return measurement, nil
+}
+
+func runDownloadRequest(ctx context.Context, client *http.Client, rawURL string, onActive func()) error {
+	req, err := newRequest(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	err = validateResponse(resp)
+	if err != nil {
+		return err
+	}
+	if onActive != nil {
+		onActive()
+	}
+	_, err = sBufio.Copy(io.Discard, resp.Body)
+	if ctx.Err() != nil {
+		return nil
+	}
+	return err
+}
+
+func runUploadRequest(ctx context.Context, client *http.Client, rawURL string, onActive func()) error {
+	body := &uploadBody{
+		remaining: settings.uploadRequestSize,
+		onActive:  onActive,
+	}
+	req, err := newRequest(ctx, http.MethodPost, rawURL, body)
+	if err != nil {
+		return err
+	}
+	req.ContentLength = settings.uploadRequestSize
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	err = validateResponse(resp)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(io.Discard, resp.Body)
+	return err
+}
+
+func newRequest(ctx context.Context, method string, rawURL string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	return req, nil
+}
+
+func validateResponse(resp *http.Response) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return E.New("unexpected status: ", resp.Status)
+	}
+	if encoding := resp.Header.Get("Content-Encoding"); encoding != "" {
+		return E.New("unexpected content encoding: ", encoding)
+	}
+	return nil
+}
+
+func calculateRPM(rounds []probeRound) int32 {
+	if len(rounds) == 0 {
+		return 0
+	}
+	var tcpSamples []float64
+	var tlsSamples []float64
+	var httpFirstSamples []float64
+	var httpLoadedSamples []float64
+	for _, round := range rounds {
+		if round.tcp > 0 {
+			tcpSamples = append(tcpSamples, durationMillis(round.tcp))
+		}
+		if round.tls > 0 {
+			tlsSamples = append(tlsSamples, durationMillis(round.tls))
+		}
+		if round.httpFirst > 0 {
+			httpFirstSamples = append(httpFirstSamples, durationMillis(round.httpFirst))
+		}
+		if round.httpLoaded > 0 {
+			httpLoadedSamples = append(httpLoadedSamples, durationMillis(round.httpLoaded))
+		}
+	}
+	httpLoaded := upperTrimmedMean(httpLoadedSamples, settings.trimPercent)
+	if httpLoaded <= 0 {
+		return 0
+	}
+	var foreignComponents []float64
+	if tcp := upperTrimmedMean(tcpSamples, settings.trimPercent); tcp > 0 {
+		foreignComponents = append(foreignComponents, tcp)
+	}
+	if tls := upperTrimmedMean(tlsSamples, settings.trimPercent); tls > 0 {
+		foreignComponents = append(foreignComponents, tls)
+	}
+	if httpFirst := upperTrimmedMean(httpFirstSamples, settings.trimPercent); httpFirst > 0 {
+		foreignComponents = append(foreignComponents, httpFirst)
+	}
+	if len(foreignComponents) == 0 {
+		return 0
+	}
+	foreignLatency := meanFloat64s(foreignComponents)
+	foreignRPM := 60000.0 / foreignLatency
+	loadedRPM := 60000.0 / httpLoaded
+	return int32(math.Round((foreignRPM + loadedRPM) / 2))
+}
+
+func durationMillis(value time.Duration) float64 {
+	return float64(value) / float64(time.Millisecond)
+}
+
+func upperTrimmedMean(values []float64, trimPercent int) float64 {
+	trimmed := upperTrimFloat64s(values, trimPercent)
+	if len(trimmed) == 0 {
+		return 0
+	}
+	return meanFloat64s(trimmed)
+}
+
+func upperTrimFloat64s(values []float64, trimPercent int) []float64 {
+	if len(values) == 0 {
+		return nil
+	}
+	trimmed := append([]float64(nil), values...)
+	sort.Float64s(trimmed)
+	if trimPercent <= 0 {
+		return trimmed
+	}
+	trimCount := int(math.Floor(float64(len(trimmed)) * float64(trimPercent) / 100))
+	if trimCount <= 0 || trimCount >= len(trimmed) {
+		return trimmed
+	}
+	return trimmed[:len(trimmed)-trimCount]
+}
+
+func meanFloat64s(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	var total float64
+	for _, value := range values {
+		total += value
+	}
+	return total / float64(len(values))
+}
+
+func stdDevFloat64s(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	mean := meanFloat64s(values)
+	var total float64
+	for _, value := range values {
+		delta := value - mean
+		total += delta * delta
+	}
+	return math.Sqrt(total / float64(len(values)))
+}
+
+type uploadBody struct {
+	remaining int64
+	activated atomic.Bool
+	onActive  func()
+}
+
+func (u *uploadBody) Read(p []byte) (int, error) {
+	if u.remaining == 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > u.remaining {
+		p = p[:int(u.remaining)]
+	}
+	clear(p)
+	n := len(p)
+	if n > 0 && u.onActive != nil && u.activated.CompareAndSwap(false, true) {
+		u.onActive()
+	}
+	u.remaining -= int64(n)
+	if u.remaining == 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (u *uploadBody) Close() error {
+	return nil
+}

--- a/common/srs/binary.go
+++ b/common/srs/binary.go
@@ -46,6 +46,7 @@ const (
 	ruleItemNetworkIsConstrained
 	ruleItemNetworkInterfaceAddress
 	ruleItemDefaultInterfaceAddress
+	ruleItemPackageNameRegex
 	ruleItemFinal uint8 = 0xFF
 )
 
@@ -215,6 +216,8 @@ func readDefaultRule(reader varbin.Reader, recover bool) (rule option.DefaultHea
 			rule.ProcessPathRegex, err = readRuleItemString(reader)
 		case ruleItemPackageName:
 			rule.PackageName, err = readRuleItemString(reader)
+		case ruleItemPackageNameRegex:
+			rule.PackageNameRegex, err = readRuleItemString(reader)
 		case ruleItemWIFISSID:
 			rule.WIFISSID, err = readRuleItemString(reader)
 		case ruleItemWIFIBSSID:
@@ -390,6 +393,15 @@ func writeDefaultRule(writer varbin.Writer, rule option.DefaultHeadlessRule, gen
 	}
 	if len(rule.PackageName) > 0 {
 		err = writeRuleItemString(writer, ruleItemPackageName, rule.PackageName)
+		if err != nil {
+			return err
+		}
+	}
+	if len(rule.PackageNameRegex) > 0 {
+		if generateVersion < C.RuleSetVersion5 {
+			return E.New("`package_name_regex` rule item is only supported in version 5 or later")
+		}
+		err = writeRuleItemString(writer, ruleItemPackageNameRegex, rule.PackageNameRegex)
 		if err != nil {
 			return err
 		}

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -23,7 +23,8 @@ const (
 	RuleSetVersion2
 	RuleSetVersion3
 	RuleSetVersion4
-	RuleSetVersionCurrent = RuleSetVersion4
+	RuleSetVersion5
+	RuleSetVersionCurrent = RuleSetVersion5
 )
 
 const (

--- a/daemon/started_service.go
+++ b/daemon/started_service.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/dialer"
+	"github.com/sagernet/sing-box/common/networkquality"
 	"github.com/sagernet/sing-box/common/urltest"
 	"github.com/sagernet/sing-box/experimental/clashapi"
 	"github.com/sagernet/sing-box/experimental/clashapi/trafficontrol"
@@ -1078,6 +1080,149 @@ func (s *StartedService) GetStartedAt(ctx context.Context, empty *emptypb.Empty)
 	s.serviceAccess.RLock()
 	defer s.serviceAccess.RUnlock()
 	return &StartedAt{StartedAt: s.startedAt.UnixMilli()}, nil
+}
+
+func (s *StartedService) ListOutbounds(ctx context.Context, _ *emptypb.Empty) (*OutboundList, error) {
+	s.serviceAccess.RLock()
+	if s.serviceStatus.Status != ServiceStatus_STARTED {
+		s.serviceAccess.RUnlock()
+		return nil, os.ErrInvalid
+	}
+	boxService := s.instance
+	s.serviceAccess.RUnlock()
+	historyStorage := boxService.urlTestHistoryStorage
+	outbounds := boxService.instance.Outbound().Outbounds()
+	var list OutboundList
+	for _, ob := range outbounds {
+		item := &GroupItem{
+			Tag:  ob.Tag(),
+			Type: ob.Type(),
+		}
+		if history := historyStorage.LoadURLTestHistory(adapter.OutboundTag(ob)); history != nil {
+			item.UrlTestTime = history.Time.Unix()
+			item.UrlTestDelay = int32(history.Delay)
+		}
+		list.Outbounds = append(list.Outbounds, item)
+	}
+	return &list, nil
+}
+
+func (s *StartedService) SubscribeOutbounds(_ *emptypb.Empty, server grpc.ServerStreamingServer[OutboundList]) error {
+	err := s.waitForStarted(server.Context())
+	if err != nil {
+		return err
+	}
+	subscription, done, err := s.urlTestObserver.Subscribe()
+	if err != nil {
+		return err
+	}
+	defer s.urlTestObserver.UnSubscribe(subscription)
+	for {
+		s.serviceAccess.RLock()
+		if s.serviceStatus.Status != ServiceStatus_STARTED {
+			s.serviceAccess.RUnlock()
+			return os.ErrInvalid
+		}
+		boxService := s.instance
+		s.serviceAccess.RUnlock()
+		historyStorage := boxService.urlTestHistoryStorage
+		outbounds := boxService.instance.Outbound().Outbounds()
+		var list OutboundList
+		for _, ob := range outbounds {
+			item := &GroupItem{
+				Tag:  ob.Tag(),
+				Type: ob.Type(),
+			}
+			if history := historyStorage.LoadURLTestHistory(adapter.OutboundTag(ob)); history != nil {
+				item.UrlTestTime = history.Time.Unix()
+				item.UrlTestDelay = int32(history.Delay)
+			}
+			list.Outbounds = append(list.Outbounds, item)
+		}
+		err = server.Send(&list)
+		if err != nil {
+			return err
+		}
+		select {
+		case <-subscription:
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		case <-server.Context().Done():
+			return server.Context().Err()
+		case <-done:
+			return nil
+		}
+	}
+}
+
+func (s *StartedService) StartNetworkQualityTest(
+	request *NetworkQualityTestRequest,
+	server grpc.ServerStreamingServer[NetworkQualityTestProgress],
+) error {
+	err := s.waitForStarted(server.Context())
+	if err != nil {
+		return err
+	}
+	s.serviceAccess.RLock()
+	boxService := s.instance
+	s.serviceAccess.RUnlock()
+
+	var outbound adapter.Outbound
+	if request.OutboundTag == "" {
+		outbound = boxService.instance.Outbound().Default()
+	} else {
+		var loaded bool
+		outbound, loaded = boxService.instance.Outbound().Outbound(request.OutboundTag)
+		if !loaded {
+			return E.New("outbound not found: ", request.OutboundTag)
+		}
+	}
+
+	resolvedDialer := dialer.NewResolveDialer(boxService.ctx, outbound, true, "", adapter.DNSQueryOptions{}, 0)
+	httpClient := networkquality.NewHTTPClient(resolvedDialer)
+	defer httpClient.CloseIdleConnections()
+
+	result, nqErr := networkquality.Run(networkquality.Options{
+		ConfigURL:  request.ConfigURL,
+		HTTPClient: httpClient,
+		Serial:     request.Serial,
+		MaxRuntime: time.Duration(request.MaxRuntimeSeconds) * time.Second,
+		Context:    server.Context(),
+		OnProgress: func(p networkquality.Progress) {
+			_ = server.Send(&NetworkQualityTestProgress{
+				Phase:                    int32(p.Phase),
+				DownloadCapacity:         p.DownloadCapacity,
+				UploadCapacity:           p.UploadCapacity,
+				DownloadRPM:              p.DownloadRPM,
+				UploadRPM:                p.UploadRPM,
+				IdleLatencyMs:            p.IdleLatencyMs,
+				ElapsedMs:                p.ElapsedMs,
+				DownloadCapacityAccuracy: int32(p.DownloadCapacityAccuracy),
+				UploadCapacityAccuracy:   int32(p.UploadCapacityAccuracy),
+				DownloadRPMAccuracy:      int32(p.DownloadRPMAccuracy),
+				UploadRPMAccuracy:        int32(p.UploadRPMAccuracy),
+			})
+		},
+	})
+	if nqErr != nil {
+		return server.Send(&NetworkQualityTestProgress{
+			IsFinal: true,
+			Error:   nqErr.Error(),
+		})
+	}
+	return server.Send(&NetworkQualityTestProgress{
+		Phase:                    int32(networkquality.PhaseDone),
+		DownloadCapacity:         result.DownloadCapacity,
+		UploadCapacity:           result.UploadCapacity,
+		DownloadRPM:              result.DownloadRPM,
+		UploadRPM:                result.UploadRPM,
+		IdleLatencyMs:            result.IdleLatencyMs,
+		IsFinal:                  true,
+		DownloadCapacityAccuracy: int32(result.DownloadCapacityAccuracy),
+		UploadCapacityAccuracy:   int32(result.UploadCapacityAccuracy),
+		DownloadRPMAccuracy:      int32(result.DownloadRPMAccuracy),
+		UploadRPMAccuracy:        int32(result.UploadRPMAccuracy),
+	})
 }
 
 func (s *StartedService) mustEmbedUnimplementedStartedServiceServer() {

--- a/daemon/started_service.pb.go
+++ b/daemon/started_service.pb.go
@@ -1836,6 +1836,258 @@ func (x *StartedAt) GetStartedAt() int64 {
 	return 0
 }
 
+type OutboundList struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Outbounds     []*GroupItem           `protobuf:"bytes,1,rep,name=outbounds,proto3" json:"outbounds,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OutboundList) Reset() {
+	*x = OutboundList{}
+	mi := &file_daemon_started_service_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OutboundList) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OutboundList) ProtoMessage() {}
+
+func (x *OutboundList) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_started_service_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OutboundList.ProtoReflect.Descriptor instead.
+func (*OutboundList) Descriptor() ([]byte, []int) {
+	return file_daemon_started_service_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *OutboundList) GetOutbounds() []*GroupItem {
+	if x != nil {
+		return x.Outbounds
+	}
+	return nil
+}
+
+type NetworkQualityTestRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	ConfigURL         string                 `protobuf:"bytes,1,opt,name=configURL,proto3" json:"configURL,omitempty"`
+	OutboundTag       string                 `protobuf:"bytes,2,opt,name=outboundTag,proto3" json:"outboundTag,omitempty"`
+	Serial            bool                   `protobuf:"varint,3,opt,name=serial,proto3" json:"serial,omitempty"`
+	MaxRuntimeSeconds int32                  `protobuf:"varint,4,opt,name=maxRuntimeSeconds,proto3" json:"maxRuntimeSeconds,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *NetworkQualityTestRequest) Reset() {
+	*x = NetworkQualityTestRequest{}
+	mi := &file_daemon_started_service_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NetworkQualityTestRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NetworkQualityTestRequest) ProtoMessage() {}
+
+func (x *NetworkQualityTestRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_started_service_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NetworkQualityTestRequest.ProtoReflect.Descriptor instead.
+func (*NetworkQualityTestRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_started_service_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *NetworkQualityTestRequest) GetConfigURL() string {
+	if x != nil {
+		return x.ConfigURL
+	}
+	return ""
+}
+
+func (x *NetworkQualityTestRequest) GetOutboundTag() string {
+	if x != nil {
+		return x.OutboundTag
+	}
+	return ""
+}
+
+func (x *NetworkQualityTestRequest) GetSerial() bool {
+	if x != nil {
+		return x.Serial
+	}
+	return false
+}
+
+func (x *NetworkQualityTestRequest) GetMaxRuntimeSeconds() int32 {
+	if x != nil {
+		return x.MaxRuntimeSeconds
+	}
+	return 0
+}
+
+type NetworkQualityTestProgress struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	Phase                    int32                  `protobuf:"varint,1,opt,name=phase,proto3" json:"phase,omitempty"`
+	DownloadCapacity         int64                  `protobuf:"varint,2,opt,name=downloadCapacity,proto3" json:"downloadCapacity,omitempty"`
+	UploadCapacity           int64                  `protobuf:"varint,3,opt,name=uploadCapacity,proto3" json:"uploadCapacity,omitempty"`
+	DownloadRPM              int32                  `protobuf:"varint,4,opt,name=downloadRPM,proto3" json:"downloadRPM,omitempty"`
+	UploadRPM                int32                  `protobuf:"varint,5,opt,name=uploadRPM,proto3" json:"uploadRPM,omitempty"`
+	IdleLatencyMs            int32                  `protobuf:"varint,6,opt,name=idleLatencyMs,proto3" json:"idleLatencyMs,omitempty"`
+	ElapsedMs                int64                  `protobuf:"varint,7,opt,name=elapsedMs,proto3" json:"elapsedMs,omitempty"`
+	IsFinal                  bool                   `protobuf:"varint,8,opt,name=isFinal,proto3" json:"isFinal,omitempty"`
+	Error                    string                 `protobuf:"bytes,9,opt,name=error,proto3" json:"error,omitempty"`
+	DownloadCapacityAccuracy int32                  `protobuf:"varint,10,opt,name=downloadCapacityAccuracy,proto3" json:"downloadCapacityAccuracy,omitempty"`
+	UploadCapacityAccuracy   int32                  `protobuf:"varint,11,opt,name=uploadCapacityAccuracy,proto3" json:"uploadCapacityAccuracy,omitempty"`
+	DownloadRPMAccuracy      int32                  `protobuf:"varint,12,opt,name=downloadRPMAccuracy,proto3" json:"downloadRPMAccuracy,omitempty"`
+	UploadRPMAccuracy        int32                  `protobuf:"varint,13,opt,name=uploadRPMAccuracy,proto3" json:"uploadRPMAccuracy,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *NetworkQualityTestProgress) Reset() {
+	*x = NetworkQualityTestProgress{}
+	mi := &file_daemon_started_service_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NetworkQualityTestProgress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NetworkQualityTestProgress) ProtoMessage() {}
+
+func (x *NetworkQualityTestProgress) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_started_service_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NetworkQualityTestProgress.ProtoReflect.Descriptor instead.
+func (*NetworkQualityTestProgress) Descriptor() ([]byte, []int) {
+	return file_daemon_started_service_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *NetworkQualityTestProgress) GetPhase() int32 {
+	if x != nil {
+		return x.Phase
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetDownloadCapacity() int64 {
+	if x != nil {
+		return x.DownloadCapacity
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetUploadCapacity() int64 {
+	if x != nil {
+		return x.UploadCapacity
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetDownloadRPM() int32 {
+	if x != nil {
+		return x.DownloadRPM
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetUploadRPM() int32 {
+	if x != nil {
+		return x.UploadRPM
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetIdleLatencyMs() int32 {
+	if x != nil {
+		return x.IdleLatencyMs
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetElapsedMs() int64 {
+	if x != nil {
+		return x.ElapsedMs
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetIsFinal() bool {
+	if x != nil {
+		return x.IsFinal
+	}
+	return false
+}
+
+func (x *NetworkQualityTestProgress) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *NetworkQualityTestProgress) GetDownloadCapacityAccuracy() int32 {
+	if x != nil {
+		return x.DownloadCapacityAccuracy
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetUploadCapacityAccuracy() int32 {
+	if x != nil {
+		return x.UploadCapacityAccuracy
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetDownloadRPMAccuracy() int32 {
+	if x != nil {
+		return x.DownloadRPMAccuracy
+	}
+	return 0
+}
+
+func (x *NetworkQualityTestProgress) GetUploadRPMAccuracy() int32 {
+	if x != nil {
+		return x.UploadRPMAccuracy
+	}
+	return 0
+}
+
 type Log_Message struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Level         LogLevel               `protobuf:"varint,1,opt,name=level,proto3,enum=daemon.LogLevel" json:"level,omitempty"`
@@ -1846,7 +2098,7 @@ type Log_Message struct {
 
 func (x *Log_Message) Reset() {
 	*x = Log_Message{}
-	mi := &file_daemon_started_service_proto_msgTypes[26]
+	mi := &file_daemon_started_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1858,7 +2110,7 @@ func (x *Log_Message) String() string {
 func (*Log_Message) ProtoMessage() {}
 
 func (x *Log_Message) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_started_service_proto_msgTypes[26]
+	mi := &file_daemon_started_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2023,7 +2275,29 @@ const file_daemon_started_service_proto_rawDesc = "" +
 	"\x11deprecatedVersion\x18\x05 \x01(\tR\x11deprecatedVersion\x12*\n" +
 	"\x10scheduledVersion\x18\x06 \x01(\tR\x10scheduledVersion\")\n" +
 	"\tStartedAt\x12\x1c\n" +
-	"\tstartedAt\x18\x01 \x01(\x03R\tstartedAt*U\n" +
+	"\tstartedAt\x18\x01 \x01(\x03R\tstartedAt\"?\n" +
+	"\fOutboundList\x12/\n" +
+	"\toutbounds\x18\x01 \x03(\v2\x11.daemon.GroupItemR\toutbounds\"\xa1\x01\n" +
+	"\x19NetworkQualityTestRequest\x12\x1c\n" +
+	"\tconfigURL\x18\x01 \x01(\tR\tconfigURL\x12 \n" +
+	"\voutboundTag\x18\x02 \x01(\tR\voutboundTag\x12\x16\n" +
+	"\x06serial\x18\x03 \x01(\bR\x06serial\x12,\n" +
+	"\x11maxRuntimeSeconds\x18\x04 \x01(\x05R\x11maxRuntimeSeconds\"\x8e\x04\n" +
+	"\x1aNetworkQualityTestProgress\x12\x14\n" +
+	"\x05phase\x18\x01 \x01(\x05R\x05phase\x12*\n" +
+	"\x10downloadCapacity\x18\x02 \x01(\x03R\x10downloadCapacity\x12&\n" +
+	"\x0euploadCapacity\x18\x03 \x01(\x03R\x0euploadCapacity\x12 \n" +
+	"\vdownloadRPM\x18\x04 \x01(\x05R\vdownloadRPM\x12\x1c\n" +
+	"\tuploadRPM\x18\x05 \x01(\x05R\tuploadRPM\x12$\n" +
+	"\ridleLatencyMs\x18\x06 \x01(\x05R\ridleLatencyMs\x12\x1c\n" +
+	"\telapsedMs\x18\a \x01(\x03R\telapsedMs\x12\x18\n" +
+	"\aisFinal\x18\b \x01(\bR\aisFinal\x12\x14\n" +
+	"\x05error\x18\t \x01(\tR\x05error\x12:\n" +
+	"\x18downloadCapacityAccuracy\x18\n" +
+	" \x01(\x05R\x18downloadCapacityAccuracy\x126\n" +
+	"\x16uploadCapacityAccuracy\x18\v \x01(\x05R\x16uploadCapacityAccuracy\x120\n" +
+	"\x13downloadRPMAccuracy\x18\f \x01(\x05R\x13downloadRPMAccuracy\x12,\n" +
+	"\x11uploadRPMAccuracy\x18\r \x01(\x05R\x11uploadRPMAccuracy*U\n" +
 	"\bLogLevel\x12\t\n" +
 	"\x05PANIC\x10\x00\x12\t\n" +
 	"\x05FATAL\x10\x01\x12\t\n" +
@@ -2035,7 +2309,7 @@ const file_daemon_started_service_proto_rawDesc = "" +
 	"\x13ConnectionEventType\x12\x18\n" +
 	"\x14CONNECTION_EVENT_NEW\x10\x00\x12\x1b\n" +
 	"\x17CONNECTION_EVENT_UPDATE\x10\x01\x12\x1b\n" +
-	"\x17CONNECTION_EVENT_CLOSED\x10\x022\xf5\f\n" +
+	"\x17CONNECTION_EVENT_CLOSED\x10\x022\xe4\x0e\n" +
 	"\x0eStartedService\x12=\n" +
 	"\vStopService\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12?\n" +
 	"\rReloadService\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\x12K\n" +
@@ -2059,7 +2333,10 @@ const file_daemon_started_service_proto_rawDesc = "" +
 	"\x0fCloseConnection\x12\x1e.daemon.CloseConnectionRequest\x1a\x16.google.protobuf.Empty\"\x00\x12G\n" +
 	"\x13CloseAllConnections\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\"\x00\x12M\n" +
 	"\x15GetDeprecatedWarnings\x12\x16.google.protobuf.Empty\x1a\x1a.daemon.DeprecatedWarnings\"\x00\x12;\n" +
-	"\fGetStartedAt\x12\x16.google.protobuf.Empty\x1a\x11.daemon.StartedAt\"\x00B%Z#github.com/sagernet/sing-box/daemonb\x06proto3"
+	"\fGetStartedAt\x12\x16.google.protobuf.Empty\x1a\x11.daemon.StartedAt\"\x00\x12?\n" +
+	"\rListOutbounds\x12\x16.google.protobuf.Empty\x1a\x14.daemon.OutboundList\"\x00\x12F\n" +
+	"\x12SubscribeOutbounds\x12\x16.google.protobuf.Empty\x1a\x14.daemon.OutboundList\"\x000\x01\x12d\n" +
+	"\x17StartNetworkQualityTest\x12!.daemon.NetworkQualityTestRequest\x1a\".daemon.NetworkQualityTestProgress\"\x000\x01B%Z#github.com/sagernet/sing-box/daemonb\x06proto3"
 
 var (
 	file_daemon_started_service_proto_rawDescOnce sync.Once
@@ -2075,7 +2352,7 @@ func file_daemon_started_service_proto_rawDescGZIP() []byte {
 
 var (
 	file_daemon_started_service_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-	file_daemon_started_service_proto_msgTypes  = make([]protoimpl.MessageInfo, 27)
+	file_daemon_started_service_proto_msgTypes  = make([]protoimpl.MessageInfo, 30)
 	file_daemon_started_service_proto_goTypes   = []any{
 		(LogLevel)(0),                        // 0: daemon.LogLevel
 		(ConnectionEventType)(0),             // 1: daemon.ConnectionEventType
@@ -2107,14 +2384,17 @@ var (
 		(*DeprecatedWarnings)(nil),           // 27: daemon.DeprecatedWarnings
 		(*DeprecatedWarning)(nil),            // 28: daemon.DeprecatedWarning
 		(*StartedAt)(nil),                    // 29: daemon.StartedAt
-		(*Log_Message)(nil),                  // 30: daemon.Log.Message
-		(*emptypb.Empty)(nil),                // 31: google.protobuf.Empty
+		(*OutboundList)(nil),                 // 30: daemon.OutboundList
+		(*NetworkQualityTestRequest)(nil),    // 31: daemon.NetworkQualityTestRequest
+		(*NetworkQualityTestProgress)(nil),   // 32: daemon.NetworkQualityTestProgress
+		(*Log_Message)(nil),                  // 33: daemon.Log.Message
+		(*emptypb.Empty)(nil),                // 34: google.protobuf.Empty
 	}
 )
 
 var file_daemon_started_service_proto_depIdxs = []int32{
 	2,  // 0: daemon.ServiceStatus.status:type_name -> daemon.ServiceStatus.Type
-	30, // 1: daemon.Log.messages:type_name -> daemon.Log.Message
+	33, // 1: daemon.Log.messages:type_name -> daemon.Log.Message
 	0,  // 2: daemon.DefaultLogLevel.level:type_name -> daemon.LogLevel
 	11, // 3: daemon.Groups.group:type_name -> daemon.Group
 	12, // 4: daemon.Group.items:type_name -> daemon.GroupItem
@@ -2124,58 +2404,65 @@ var file_daemon_started_service_proto_depIdxs = []int32{
 	22, // 8: daemon.ConnectionEvents.events:type_name -> daemon.ConnectionEvent
 	25, // 9: daemon.Connection.processInfo:type_name -> daemon.ProcessInfo
 	28, // 10: daemon.DeprecatedWarnings.warnings:type_name -> daemon.DeprecatedWarning
-	0,  // 11: daemon.Log.Message.level:type_name -> daemon.LogLevel
-	31, // 12: daemon.StartedService.StopService:input_type -> google.protobuf.Empty
-	31, // 13: daemon.StartedService.ReloadService:input_type -> google.protobuf.Empty
-	31, // 14: daemon.StartedService.SubscribeServiceStatus:input_type -> google.protobuf.Empty
-	31, // 15: daemon.StartedService.SubscribeLog:input_type -> google.protobuf.Empty
-	31, // 16: daemon.StartedService.GetDefaultLogLevel:input_type -> google.protobuf.Empty
-	31, // 17: daemon.StartedService.ClearLogs:input_type -> google.protobuf.Empty
-	6,  // 18: daemon.StartedService.SubscribeStatus:input_type -> daemon.SubscribeStatusRequest
-	31, // 19: daemon.StartedService.SubscribeGroups:input_type -> google.protobuf.Empty
-	31, // 20: daemon.StartedService.GetClashModeStatus:input_type -> google.protobuf.Empty
-	31, // 21: daemon.StartedService.SubscribeClashMode:input_type -> google.protobuf.Empty
-	16, // 22: daemon.StartedService.SetClashMode:input_type -> daemon.ClashMode
-	13, // 23: daemon.StartedService.URLTest:input_type -> daemon.URLTestRequest
-	14, // 24: daemon.StartedService.SelectOutbound:input_type -> daemon.SelectOutboundRequest
-	15, // 25: daemon.StartedService.SetGroupExpand:input_type -> daemon.SetGroupExpandRequest
-	31, // 26: daemon.StartedService.GetSystemProxyStatus:input_type -> google.protobuf.Empty
-	19, // 27: daemon.StartedService.SetSystemProxyEnabled:input_type -> daemon.SetSystemProxyEnabledRequest
-	20, // 28: daemon.StartedService.TriggerDebugCrash:input_type -> daemon.DebugCrashRequest
-	31, // 29: daemon.StartedService.TriggerOOMReport:input_type -> google.protobuf.Empty
-	21, // 30: daemon.StartedService.SubscribeConnections:input_type -> daemon.SubscribeConnectionsRequest
-	26, // 31: daemon.StartedService.CloseConnection:input_type -> daemon.CloseConnectionRequest
-	31, // 32: daemon.StartedService.CloseAllConnections:input_type -> google.protobuf.Empty
-	31, // 33: daemon.StartedService.GetDeprecatedWarnings:input_type -> google.protobuf.Empty
-	31, // 34: daemon.StartedService.GetStartedAt:input_type -> google.protobuf.Empty
-	31, // 35: daemon.StartedService.StopService:output_type -> google.protobuf.Empty
-	31, // 36: daemon.StartedService.ReloadService:output_type -> google.protobuf.Empty
-	4,  // 37: daemon.StartedService.SubscribeServiceStatus:output_type -> daemon.ServiceStatus
-	7,  // 38: daemon.StartedService.SubscribeLog:output_type -> daemon.Log
-	8,  // 39: daemon.StartedService.GetDefaultLogLevel:output_type -> daemon.DefaultLogLevel
-	31, // 40: daemon.StartedService.ClearLogs:output_type -> google.protobuf.Empty
-	9,  // 41: daemon.StartedService.SubscribeStatus:output_type -> daemon.Status
-	10, // 42: daemon.StartedService.SubscribeGroups:output_type -> daemon.Groups
-	17, // 43: daemon.StartedService.GetClashModeStatus:output_type -> daemon.ClashModeStatus
-	16, // 44: daemon.StartedService.SubscribeClashMode:output_type -> daemon.ClashMode
-	31, // 45: daemon.StartedService.SetClashMode:output_type -> google.protobuf.Empty
-	31, // 46: daemon.StartedService.URLTest:output_type -> google.protobuf.Empty
-	31, // 47: daemon.StartedService.SelectOutbound:output_type -> google.protobuf.Empty
-	31, // 48: daemon.StartedService.SetGroupExpand:output_type -> google.protobuf.Empty
-	18, // 49: daemon.StartedService.GetSystemProxyStatus:output_type -> daemon.SystemProxyStatus
-	31, // 50: daemon.StartedService.SetSystemProxyEnabled:output_type -> google.protobuf.Empty
-	31, // 51: daemon.StartedService.TriggerDebugCrash:output_type -> google.protobuf.Empty
-	31, // 52: daemon.StartedService.TriggerOOMReport:output_type -> google.protobuf.Empty
-	23, // 53: daemon.StartedService.SubscribeConnections:output_type -> daemon.ConnectionEvents
-	31, // 54: daemon.StartedService.CloseConnection:output_type -> google.protobuf.Empty
-	31, // 55: daemon.StartedService.CloseAllConnections:output_type -> google.protobuf.Empty
-	27, // 56: daemon.StartedService.GetDeprecatedWarnings:output_type -> daemon.DeprecatedWarnings
-	29, // 57: daemon.StartedService.GetStartedAt:output_type -> daemon.StartedAt
-	35, // [35:58] is the sub-list for method output_type
-	12, // [12:35] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	12, // 11: daemon.OutboundList.outbounds:type_name -> daemon.GroupItem
+	0,  // 12: daemon.Log.Message.level:type_name -> daemon.LogLevel
+	34, // 13: daemon.StartedService.StopService:input_type -> google.protobuf.Empty
+	34, // 14: daemon.StartedService.ReloadService:input_type -> google.protobuf.Empty
+	34, // 15: daemon.StartedService.SubscribeServiceStatus:input_type -> google.protobuf.Empty
+	34, // 16: daemon.StartedService.SubscribeLog:input_type -> google.protobuf.Empty
+	34, // 17: daemon.StartedService.GetDefaultLogLevel:input_type -> google.protobuf.Empty
+	34, // 18: daemon.StartedService.ClearLogs:input_type -> google.protobuf.Empty
+	6,  // 19: daemon.StartedService.SubscribeStatus:input_type -> daemon.SubscribeStatusRequest
+	34, // 20: daemon.StartedService.SubscribeGroups:input_type -> google.protobuf.Empty
+	34, // 21: daemon.StartedService.GetClashModeStatus:input_type -> google.protobuf.Empty
+	34, // 22: daemon.StartedService.SubscribeClashMode:input_type -> google.protobuf.Empty
+	16, // 23: daemon.StartedService.SetClashMode:input_type -> daemon.ClashMode
+	13, // 24: daemon.StartedService.URLTest:input_type -> daemon.URLTestRequest
+	14, // 25: daemon.StartedService.SelectOutbound:input_type -> daemon.SelectOutboundRequest
+	15, // 26: daemon.StartedService.SetGroupExpand:input_type -> daemon.SetGroupExpandRequest
+	34, // 27: daemon.StartedService.GetSystemProxyStatus:input_type -> google.protobuf.Empty
+	19, // 28: daemon.StartedService.SetSystemProxyEnabled:input_type -> daemon.SetSystemProxyEnabledRequest
+	20, // 29: daemon.StartedService.TriggerDebugCrash:input_type -> daemon.DebugCrashRequest
+	34, // 30: daemon.StartedService.TriggerOOMReport:input_type -> google.protobuf.Empty
+	21, // 31: daemon.StartedService.SubscribeConnections:input_type -> daemon.SubscribeConnectionsRequest
+	26, // 32: daemon.StartedService.CloseConnection:input_type -> daemon.CloseConnectionRequest
+	34, // 33: daemon.StartedService.CloseAllConnections:input_type -> google.protobuf.Empty
+	34, // 34: daemon.StartedService.GetDeprecatedWarnings:input_type -> google.protobuf.Empty
+	34, // 35: daemon.StartedService.GetStartedAt:input_type -> google.protobuf.Empty
+	34, // 36: daemon.StartedService.ListOutbounds:input_type -> google.protobuf.Empty
+	34, // 37: daemon.StartedService.SubscribeOutbounds:input_type -> google.protobuf.Empty
+	31, // 38: daemon.StartedService.StartNetworkQualityTest:input_type -> daemon.NetworkQualityTestRequest
+	34, // 39: daemon.StartedService.StopService:output_type -> google.protobuf.Empty
+	34, // 40: daemon.StartedService.ReloadService:output_type -> google.protobuf.Empty
+	4,  // 41: daemon.StartedService.SubscribeServiceStatus:output_type -> daemon.ServiceStatus
+	7,  // 42: daemon.StartedService.SubscribeLog:output_type -> daemon.Log
+	8,  // 43: daemon.StartedService.GetDefaultLogLevel:output_type -> daemon.DefaultLogLevel
+	34, // 44: daemon.StartedService.ClearLogs:output_type -> google.protobuf.Empty
+	9,  // 45: daemon.StartedService.SubscribeStatus:output_type -> daemon.Status
+	10, // 46: daemon.StartedService.SubscribeGroups:output_type -> daemon.Groups
+	17, // 47: daemon.StartedService.GetClashModeStatus:output_type -> daemon.ClashModeStatus
+	16, // 48: daemon.StartedService.SubscribeClashMode:output_type -> daemon.ClashMode
+	34, // 49: daemon.StartedService.SetClashMode:output_type -> google.protobuf.Empty
+	34, // 50: daemon.StartedService.URLTest:output_type -> google.protobuf.Empty
+	34, // 51: daemon.StartedService.SelectOutbound:output_type -> google.protobuf.Empty
+	34, // 52: daemon.StartedService.SetGroupExpand:output_type -> google.protobuf.Empty
+	18, // 53: daemon.StartedService.GetSystemProxyStatus:output_type -> daemon.SystemProxyStatus
+	34, // 54: daemon.StartedService.SetSystemProxyEnabled:output_type -> google.protobuf.Empty
+	34, // 55: daemon.StartedService.TriggerDebugCrash:output_type -> google.protobuf.Empty
+	34, // 56: daemon.StartedService.TriggerOOMReport:output_type -> google.protobuf.Empty
+	23, // 57: daemon.StartedService.SubscribeConnections:output_type -> daemon.ConnectionEvents
+	34, // 58: daemon.StartedService.CloseConnection:output_type -> google.protobuf.Empty
+	34, // 59: daemon.StartedService.CloseAllConnections:output_type -> google.protobuf.Empty
+	27, // 60: daemon.StartedService.GetDeprecatedWarnings:output_type -> daemon.DeprecatedWarnings
+	29, // 61: daemon.StartedService.GetStartedAt:output_type -> daemon.StartedAt
+	30, // 62: daemon.StartedService.ListOutbounds:output_type -> daemon.OutboundList
+	30, // 63: daemon.StartedService.SubscribeOutbounds:output_type -> daemon.OutboundList
+	32, // 64: daemon.StartedService.StartNetworkQualityTest:output_type -> daemon.NetworkQualityTestProgress
+	39, // [39:65] is the sub-list for method output_type
+	13, // [13:39] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_daemon_started_service_proto_init() }
@@ -2189,7 +2476,7 @@ func file_daemon_started_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_started_service_proto_rawDesc), len(file_daemon_started_service_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   27,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemon/started_service.proto
+++ b/daemon/started_service.proto
@@ -34,6 +34,10 @@ service StartedService {
   rpc CloseAllConnections(google.protobuf.Empty) returns(google.protobuf.Empty) {}
   rpc GetDeprecatedWarnings(google.protobuf.Empty) returns(DeprecatedWarnings) {}
   rpc GetStartedAt(google.protobuf.Empty) returns(StartedAt) {}
+
+  rpc ListOutbounds(google.protobuf.Empty) returns (OutboundList) {}
+  rpc SubscribeOutbounds(google.protobuf.Empty) returns (stream OutboundList) {}
+  rpc StartNetworkQualityTest(NetworkQualityTestRequest) returns (stream NetworkQualityTestProgress) {}
 }
 
 message ServiceStatus {
@@ -228,4 +232,31 @@ message DeprecatedWarning {
 
 message StartedAt {
   int64 startedAt = 1;
+}
+
+message OutboundList {
+  repeated GroupItem outbounds = 1;
+}
+
+message NetworkQualityTestRequest {
+  string configURL = 1;
+  string outboundTag = 2;
+  bool serial = 3;
+  int32 maxRuntimeSeconds = 4;
+}
+
+message NetworkQualityTestProgress {
+  int32 phase = 1;
+  int64 downloadCapacity = 2;
+  int64 uploadCapacity = 3;
+  int32 downloadRPM = 4;
+  int32 uploadRPM = 5;
+  int32 idleLatencyMs = 6;
+  int64 elapsedMs = 7;
+  bool isFinal = 8;
+  string error = 9;
+  int32 downloadCapacityAccuracy = 10;
+  int32 uploadCapacityAccuracy = 11;
+  int32 downloadRPMAccuracy = 12;
+  int32 uploadRPMAccuracy = 13;
 }

--- a/daemon/started_service_grpc.pb.go
+++ b/daemon/started_service_grpc.pb.go
@@ -15,29 +15,32 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	StartedService_StopService_FullMethodName            = "/daemon.StartedService/StopService"
-	StartedService_ReloadService_FullMethodName          = "/daemon.StartedService/ReloadService"
-	StartedService_SubscribeServiceStatus_FullMethodName = "/daemon.StartedService/SubscribeServiceStatus"
-	StartedService_SubscribeLog_FullMethodName           = "/daemon.StartedService/SubscribeLog"
-	StartedService_GetDefaultLogLevel_FullMethodName     = "/daemon.StartedService/GetDefaultLogLevel"
-	StartedService_ClearLogs_FullMethodName              = "/daemon.StartedService/ClearLogs"
-	StartedService_SubscribeStatus_FullMethodName        = "/daemon.StartedService/SubscribeStatus"
-	StartedService_SubscribeGroups_FullMethodName        = "/daemon.StartedService/SubscribeGroups"
-	StartedService_GetClashModeStatus_FullMethodName     = "/daemon.StartedService/GetClashModeStatus"
-	StartedService_SubscribeClashMode_FullMethodName     = "/daemon.StartedService/SubscribeClashMode"
-	StartedService_SetClashMode_FullMethodName           = "/daemon.StartedService/SetClashMode"
-	StartedService_URLTest_FullMethodName                = "/daemon.StartedService/URLTest"
-	StartedService_SelectOutbound_FullMethodName         = "/daemon.StartedService/SelectOutbound"
-	StartedService_SetGroupExpand_FullMethodName         = "/daemon.StartedService/SetGroupExpand"
-	StartedService_GetSystemProxyStatus_FullMethodName   = "/daemon.StartedService/GetSystemProxyStatus"
-	StartedService_SetSystemProxyEnabled_FullMethodName  = "/daemon.StartedService/SetSystemProxyEnabled"
-	StartedService_TriggerDebugCrash_FullMethodName      = "/daemon.StartedService/TriggerDebugCrash"
-	StartedService_TriggerOOMReport_FullMethodName       = "/daemon.StartedService/TriggerOOMReport"
-	StartedService_SubscribeConnections_FullMethodName   = "/daemon.StartedService/SubscribeConnections"
-	StartedService_CloseConnection_FullMethodName        = "/daemon.StartedService/CloseConnection"
-	StartedService_CloseAllConnections_FullMethodName    = "/daemon.StartedService/CloseAllConnections"
-	StartedService_GetDeprecatedWarnings_FullMethodName  = "/daemon.StartedService/GetDeprecatedWarnings"
-	StartedService_GetStartedAt_FullMethodName           = "/daemon.StartedService/GetStartedAt"
+	StartedService_StopService_FullMethodName             = "/daemon.StartedService/StopService"
+	StartedService_ReloadService_FullMethodName           = "/daemon.StartedService/ReloadService"
+	StartedService_SubscribeServiceStatus_FullMethodName  = "/daemon.StartedService/SubscribeServiceStatus"
+	StartedService_SubscribeLog_FullMethodName            = "/daemon.StartedService/SubscribeLog"
+	StartedService_GetDefaultLogLevel_FullMethodName      = "/daemon.StartedService/GetDefaultLogLevel"
+	StartedService_ClearLogs_FullMethodName               = "/daemon.StartedService/ClearLogs"
+	StartedService_SubscribeStatus_FullMethodName         = "/daemon.StartedService/SubscribeStatus"
+	StartedService_SubscribeGroups_FullMethodName         = "/daemon.StartedService/SubscribeGroups"
+	StartedService_GetClashModeStatus_FullMethodName      = "/daemon.StartedService/GetClashModeStatus"
+	StartedService_SubscribeClashMode_FullMethodName      = "/daemon.StartedService/SubscribeClashMode"
+	StartedService_SetClashMode_FullMethodName            = "/daemon.StartedService/SetClashMode"
+	StartedService_URLTest_FullMethodName                 = "/daemon.StartedService/URLTest"
+	StartedService_SelectOutbound_FullMethodName          = "/daemon.StartedService/SelectOutbound"
+	StartedService_SetGroupExpand_FullMethodName          = "/daemon.StartedService/SetGroupExpand"
+	StartedService_GetSystemProxyStatus_FullMethodName    = "/daemon.StartedService/GetSystemProxyStatus"
+	StartedService_SetSystemProxyEnabled_FullMethodName   = "/daemon.StartedService/SetSystemProxyEnabled"
+	StartedService_TriggerDebugCrash_FullMethodName       = "/daemon.StartedService/TriggerDebugCrash"
+	StartedService_TriggerOOMReport_FullMethodName        = "/daemon.StartedService/TriggerOOMReport"
+	StartedService_SubscribeConnections_FullMethodName    = "/daemon.StartedService/SubscribeConnections"
+	StartedService_CloseConnection_FullMethodName         = "/daemon.StartedService/CloseConnection"
+	StartedService_CloseAllConnections_FullMethodName     = "/daemon.StartedService/CloseAllConnections"
+	StartedService_GetDeprecatedWarnings_FullMethodName   = "/daemon.StartedService/GetDeprecatedWarnings"
+	StartedService_GetStartedAt_FullMethodName            = "/daemon.StartedService/GetStartedAt"
+	StartedService_ListOutbounds_FullMethodName           = "/daemon.StartedService/ListOutbounds"
+	StartedService_SubscribeOutbounds_FullMethodName      = "/daemon.StartedService/SubscribeOutbounds"
+	StartedService_StartNetworkQualityTest_FullMethodName = "/daemon.StartedService/StartNetworkQualityTest"
 )
 
 // StartedServiceClient is the client API for StartedService service.
@@ -67,6 +70,9 @@ type StartedServiceClient interface {
 	CloseAllConnections(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	GetDeprecatedWarnings(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*DeprecatedWarnings, error)
 	GetStartedAt(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*StartedAt, error)
+	ListOutbounds(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*OutboundList, error)
+	SubscribeOutbounds(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[OutboundList], error)
+	StartNetworkQualityTest(ctx context.Context, in *NetworkQualityTestRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[NetworkQualityTestProgress], error)
 }
 
 type startedServiceClient struct {
@@ -361,6 +367,54 @@ func (c *startedServiceClient) GetStartedAt(ctx context.Context, in *emptypb.Emp
 	return out, nil
 }
 
+func (c *startedServiceClient) ListOutbounds(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*OutboundList, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(OutboundList)
+	err := c.cc.Invoke(ctx, StartedService_ListOutbounds_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *startedServiceClient) SubscribeOutbounds(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[OutboundList], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &StartedService_ServiceDesc.Streams[6], StartedService_SubscribeOutbounds_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[emptypb.Empty, OutboundList]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type StartedService_SubscribeOutboundsClient = grpc.ServerStreamingClient[OutboundList]
+
+func (c *startedServiceClient) StartNetworkQualityTest(ctx context.Context, in *NetworkQualityTestRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[NetworkQualityTestProgress], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &StartedService_ServiceDesc.Streams[7], StartedService_StartNetworkQualityTest_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[NetworkQualityTestRequest, NetworkQualityTestProgress]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type StartedService_StartNetworkQualityTestClient = grpc.ServerStreamingClient[NetworkQualityTestProgress]
+
 // StartedServiceServer is the server API for StartedService service.
 // All implementations must embed UnimplementedStartedServiceServer
 // for forward compatibility.
@@ -388,6 +442,9 @@ type StartedServiceServer interface {
 	CloseAllConnections(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
 	GetDeprecatedWarnings(context.Context, *emptypb.Empty) (*DeprecatedWarnings, error)
 	GetStartedAt(context.Context, *emptypb.Empty) (*StartedAt, error)
+	ListOutbounds(context.Context, *emptypb.Empty) (*OutboundList, error)
+	SubscribeOutbounds(*emptypb.Empty, grpc.ServerStreamingServer[OutboundList]) error
+	StartNetworkQualityTest(*NetworkQualityTestRequest, grpc.ServerStreamingServer[NetworkQualityTestProgress]) error
 	mustEmbedUnimplementedStartedServiceServer()
 }
 
@@ -488,6 +545,18 @@ func (UnimplementedStartedServiceServer) GetDeprecatedWarnings(context.Context, 
 
 func (UnimplementedStartedServiceServer) GetStartedAt(context.Context, *emptypb.Empty) (*StartedAt, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetStartedAt not implemented")
+}
+
+func (UnimplementedStartedServiceServer) ListOutbounds(context.Context, *emptypb.Empty) (*OutboundList, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListOutbounds not implemented")
+}
+
+func (UnimplementedStartedServiceServer) SubscribeOutbounds(*emptypb.Empty, grpc.ServerStreamingServer[OutboundList]) error {
+	return status.Error(codes.Unimplemented, "method SubscribeOutbounds not implemented")
+}
+
+func (UnimplementedStartedServiceServer) StartNetworkQualityTest(*NetworkQualityTestRequest, grpc.ServerStreamingServer[NetworkQualityTestProgress]) error {
+	return status.Error(codes.Unimplemented, "method StartNetworkQualityTest not implemented")
 }
 func (UnimplementedStartedServiceServer) mustEmbedUnimplementedStartedServiceServer() {}
 func (UnimplementedStartedServiceServer) testEmbeddedByValue()                        {}
@@ -882,6 +951,46 @@ func _StartedService_GetStartedAt_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _StartedService_ListOutbounds_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StartedServiceServer).ListOutbounds(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StartedService_ListOutbounds_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StartedServiceServer).ListOutbounds(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StartedService_SubscribeOutbounds_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(emptypb.Empty)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(StartedServiceServer).SubscribeOutbounds(m, &grpc.GenericServerStream[emptypb.Empty, OutboundList]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type StartedService_SubscribeOutboundsServer = grpc.ServerStreamingServer[OutboundList]
+
+func _StartedService_StartNetworkQualityTest_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(NetworkQualityTestRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(StartedServiceServer).StartNetworkQualityTest(m, &grpc.GenericServerStream[NetworkQualityTestRequest, NetworkQualityTestProgress]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type StartedService_StartNetworkQualityTestServer = grpc.ServerStreamingServer[NetworkQualityTestProgress]
+
 // StartedService_ServiceDesc is the grpc.ServiceDesc for StartedService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -957,6 +1066,10 @@ var StartedService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "GetStartedAt",
 			Handler:    _StartedService_GetStartedAt_Handler,
 		},
+		{
+			MethodName: "ListOutbounds",
+			Handler:    _StartedService_ListOutbounds_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -987,6 +1100,16 @@ var StartedService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "SubscribeConnections",
 			Handler:       _StartedService_SubscribeConnections_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "SubscribeOutbounds",
+			Handler:       _StartedService_SubscribeOutbounds_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StartNetworkQualityTest",
+			Handler:       _StartedService_StartNetworkQualityTest_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/docs/clients/android/features.md
+++ b/docs/clients/android/features.md
@@ -42,6 +42,7 @@ SFA provides an unprivileged TUN implementation through Android VpnService.
 | `process_path`        | :material-close: | No permission                     |
 | `process_path_regex`  | :material-close: | No permission                     |
 | `package_name`        | :material-check: | /                                 |
+| `package_name_regex`  | :material-check: | /                                 |
 | `user`                | :material-close: | Use `package_name` instead        |
 | `user_id`             | :material-close: | Use `package_name` instead        |
 | `wifi_ssid`           | :material-check: | Fine location permission required |

--- a/docs/clients/apple/features.md
+++ b/docs/clients/apple/features.md
@@ -44,6 +44,7 @@ SFI/SFM/SFT provides an unprivileged TUN implementation through NetworkExtension
 | `process_path`        | :material-close: | No permission         |
 | `process_path_regex`  | :material-close: | No permission         |
 | `package_name`        | :material-close: | /                     |
+| `package_name_regex`  | :material-close: | /                     |
 | `user`                | :material-close: | No permission         |
 | `user_id`             | :material-close: | No permission         |
 | `wifi_ssid`           | :material-alert: | Only supported on iOS |

--- a/docs/configuration/dns/rule.md
+++ b/docs/configuration/dns/rule.md
@@ -130,6 +130,9 @@ icon: material/alert-decagram
         "package_name": [
           "com.termux"
         ],
+        "package_name_regex": [
+          "^com\\.termux"
+        ],
         "user": [
           "sekai"
         ],
@@ -347,6 +350,10 @@ Match process path using regular expression.
 #### package_name
 
 Match android package name.
+
+#### package_name_regex
+
+Match android package name using regular expression.
 
 #### user
 

--- a/docs/configuration/dns/rule.zh.md
+++ b/docs/configuration/dns/rule.zh.md
@@ -130,6 +130,9 @@ icon: material/alert-decagram
         "package_name": [
           "com.termux"
         ],
+        "package_name_regex": [
+          "^com\\.termux"
+        ],
         "user": [
           "sekai"
         ],
@@ -347,6 +350,10 @@ DNS 查询类型。值可以为整数或者类型名称字符串。
 #### package_name
 
 匹配 Android 应用包名。
+
+#### package_name_regex
+
+使用正则表达式匹配 Android 应用包名。
 
 #### user
 

--- a/docs/configuration/route/rule.md
+++ b/docs/configuration/route/rule.md
@@ -129,6 +129,9 @@ icon: material/new-box
         "package_name": [
           "com.termux"
         ],
+        "package_name_regex": [
+          "^com\\.termux"
+        ],
         "user": [
           "sekai"
         ],
@@ -353,6 +356,10 @@ Match process path using regular expression.
 #### package_name
 
 Match android package name.
+
+#### package_name_regex
+
+Match android package name using regular expression.
 
 #### user
 

--- a/docs/configuration/route/rule.zh.md
+++ b/docs/configuration/route/rule.zh.md
@@ -127,6 +127,9 @@ icon: material/new-box
         "package_name": [
           "com.termux"
         ],
+        "package_name_regex": [
+          "^com\\.termux"
+        ],
         "user": [
           "sekai"
         ],
@@ -351,6 +354,10 @@ icon: material/new-box
 #### package_name
 
 匹配 Android 应用包名。
+
+#### package_name_regex
+
+使用正则表达式匹配 Android 应用包名。
 
 #### user
 

--- a/docs/configuration/rule-set/headless-rule.md
+++ b/docs/configuration/rule-set/headless-rule.md
@@ -78,6 +78,9 @@ icon: material/new-box
       "package_name": [
         "com.termux"
       ],
+      "package_name_regex": [
+        "^com\\.termux"
+      ],
       "network_type": [
         "wifi"
       ],
@@ -204,6 +207,10 @@ Match process path using regular expression.
 #### package_name
 
 Match android package name.
+
+#### package_name_regex
+
+Match android package name using regular expression.
 
 #### network_type
 

--- a/docs/configuration/rule-set/headless-rule.zh.md
+++ b/docs/configuration/rule-set/headless-rule.zh.md
@@ -78,6 +78,9 @@ icon: material/new-box
       "package_name": [
         "com.termux"
       ],
+      "package_name_regex": [
+        "^com\\.termux"
+      ],
       "network_type": [
         "wifi"
       ],
@@ -200,6 +203,10 @@ DNS 查询类型。值可以为整数或者类型名称字符串。
 #### package_name
 
 匹配 Android 应用包名。
+
+#### package_name_regex
+
+使用正则表达式匹配 Android 应用包名。
 
 #### network_type
 

--- a/docs/configuration/rule-set/source-format.md
+++ b/docs/configuration/rule-set/source-format.md
@@ -41,6 +41,7 @@ Version of rule-set.
 * 2: sing-box 1.10.0: Optimized memory usages of `domain_suffix` rules in binary rule-sets.
 * 3: sing-box 1.11.0: Added `network_type`, `network_is_expensive` and `network_is_constrainted` rule items.
 * 4: sing-box 1.13.0: Added `network_interface_address` and `default_interface_address` rule items.
+* 5: Added `package_name_regex` rule item.
 
 #### rules
 

--- a/docs/configuration/rule-set/source-format.zh.md
+++ b/docs/configuration/rule-set/source-format.zh.md
@@ -41,6 +41,7 @@ icon: material/new-box
 * 2: sing-box 1.10.0: 优化了二进制规则集中 `domain_suffix` 规则的内存使用。
 * 3: sing-box 1.11.0: 添加了 `network_type`、 `network_is_expensive` 和 `network_is_constrainted` 规则项。
 * 4: sing-box 1.13.0: 添加了 `network_interface_address` 和 `default_interface_address` 规则项。
+* 5: 添加了 `package_name_regex` 规则项。
 
 #### rules
 

--- a/experimental/libbox/command.go
+++ b/experimental/libbox/command.go
@@ -6,4 +6,5 @@ const (
 	CommandGroup
 	CommandClashMode
 	CommandConnections
+	CommandOutbounds
 )

--- a/experimental/libbox/command_client.go
+++ b/experimental/libbox/command_client.go
@@ -47,6 +47,7 @@ type CommandClientHandler interface {
 	WriteLogs(messageList LogIterator)
 	WriteStatus(message *StatusMessage)
 	WriteGroups(message OutboundGroupIterator)
+	WriteOutbounds(message OutboundGroupItemIterator)
 	InitializeClashMode(modeList StringIterator, currentMode string)
 	UpdateClashMode(newMode string)
 	WriteConnectionEvents(events *ConnectionEvents)
@@ -243,6 +244,8 @@ func (c *CommandClient) dispatchCommands() error {
 			go c.handleClashModeStream()
 		case CommandConnections:
 			go c.handleConnectionsStream()
+		case CommandOutbounds:
+			go c.handleOutboundsStream()
 		default:
 			return E.New("unknown command: ", command)
 		}
@@ -456,6 +459,25 @@ func (c *CommandClient) handleConnectionsStream() {
 	}
 }
 
+func (c *CommandClient) handleOutboundsStream() {
+	client, ctx := c.getStreamContext()
+
+	stream, err := client.SubscribeOutbounds(ctx, &emptypb.Empty{})
+	if err != nil {
+		c.handler.Disconnected(err.Error())
+		return
+	}
+
+	for {
+		list, err := stream.Recv()
+		if err != nil {
+			c.handler.Disconnected(err.Error())
+			return
+		}
+		c.handler.WriteOutbounds(outboundGroupItemListFromGRPC(list))
+	}
+}
+
 func (c *CommandClient) SelectOutbound(groupTag string, outboundTag string) error {
 	_, err := callWithResult(c, func(client daemon.StartedServiceClient) (*emptypb.Empty, error) {
 		return client.SelectOutbound(context.Background(), &daemon.SelectOutboundRequest{
@@ -602,4 +624,79 @@ func (c *CommandClient) SetGroupExpand(groupTag string, isExpand bool) error {
 		})
 	})
 	return err
+}
+
+func (c *CommandClient) ListOutbounds() (OutboundGroupItemIterator, error) {
+	return callWithResult(c, func(client daemon.StartedServiceClient) (OutboundGroupItemIterator, error) {
+		list, err := client.ListOutbounds(context.Background(), &emptypb.Empty{})
+		if err != nil {
+			return nil, err
+		}
+		return outboundGroupItemListFromGRPC(list), nil
+	})
+}
+
+func (c *CommandClient) StartNetworkQualityTest(configURL string, outboundTag string, handler NetworkQualityTestHandler) error {
+	return c.StartNetworkQualityTestWithSerialAndRuntime(
+		configURL,
+		outboundTag,
+		false,
+		NetworkQualityDefaultMaxRuntimeSeconds,
+		handler,
+	)
+}
+
+func (c *CommandClient) StartNetworkQualityTestWithSerial(configURL string, outboundTag string, serial bool, handler NetworkQualityTestHandler) error {
+	return c.StartNetworkQualityTestWithSerialAndRuntime(
+		configURL,
+		outboundTag,
+		serial,
+		NetworkQualityDefaultMaxRuntimeSeconds,
+		handler,
+	)
+}
+
+func (c *CommandClient) StartNetworkQualityTestWithSerialAndRuntime(configURL string, outboundTag string, serial bool, maxRuntimeSeconds int32, handler NetworkQualityTestHandler) error {
+	client, err := c.getClientForCall()
+	if err != nil {
+		return err
+	}
+	if c.standalone {
+		defer c.closeConnection()
+	}
+	stream, err := client.StartNetworkQualityTest(context.Background(), &daemon.NetworkQualityTestRequest{
+		ConfigURL:         configURL,
+		OutboundTag:       outboundTag,
+		Serial:            serial,
+		MaxRuntimeSeconds: maxRuntimeSeconds,
+	})
+	if err != nil {
+		return err
+	}
+	for {
+		event, recvErr := stream.Recv()
+		if recvErr != nil {
+			handler.OnError(recvErr.Error())
+			return recvErr
+		}
+		if event.IsFinal {
+			if event.Error != "" {
+				handler.OnError(event.Error)
+			} else {
+				handler.OnResult(&NetworkQualityResult{
+					DownloadCapacity:         event.DownloadCapacity,
+					UploadCapacity:           event.UploadCapacity,
+					DownloadRPM:              event.DownloadRPM,
+					UploadRPM:                event.UploadRPM,
+					IdleLatencyMs:            event.IdleLatencyMs,
+					DownloadCapacityAccuracy: event.DownloadCapacityAccuracy,
+					UploadCapacityAccuracy:   event.UploadCapacityAccuracy,
+					DownloadRPMAccuracy:      event.DownloadRPMAccuracy,
+					UploadRPMAccuracy:        event.UploadRPMAccuracy,
+				})
+			}
+			return nil
+		}
+		handler.OnProgress(networkQualityProgressFromGRPC(event))
+	}
 }

--- a/experimental/libbox/command_types_nq.go
+++ b/experimental/libbox/command_types_nq.go
@@ -1,0 +1,71 @@
+package libbox
+
+import "github.com/sagernet/sing-box/daemon"
+
+type NetworkQualityProgress struct {
+	Phase                    int32
+	DownloadCapacity         int64
+	UploadCapacity           int64
+	DownloadRPM              int32
+	UploadRPM                int32
+	IdleLatencyMs            int32
+	ElapsedMs                int64
+	IsFinal                  bool
+	Error                    string
+	DownloadCapacityAccuracy int32
+	UploadCapacityAccuracy   int32
+	DownloadRPMAccuracy      int32
+	UploadRPMAccuracy        int32
+}
+
+type NetworkQualityResult struct {
+	DownloadCapacity         int64
+	UploadCapacity           int64
+	DownloadRPM              int32
+	UploadRPM                int32
+	IdleLatencyMs            int32
+	DownloadCapacityAccuracy int32
+	UploadCapacityAccuracy   int32
+	DownloadRPMAccuracy      int32
+	UploadRPMAccuracy        int32
+}
+
+type NetworkQualityTestHandler interface {
+	OnProgress(progress *NetworkQualityProgress)
+	OnResult(result *NetworkQualityResult)
+	OnError(message string)
+}
+
+func outboundGroupItemListFromGRPC(list *daemon.OutboundList) OutboundGroupItemIterator {
+	if list == nil || len(list.Outbounds) == 0 {
+		return newIterator([]*OutboundGroupItem{})
+	}
+	var items []*OutboundGroupItem
+	for _, ob := range list.Outbounds {
+		items = append(items, &OutboundGroupItem{
+			Tag:          ob.Tag,
+			Type:         ob.Type,
+			URLTestTime:  ob.UrlTestTime,
+			URLTestDelay: ob.UrlTestDelay,
+		})
+	}
+	return newIterator(items)
+}
+
+func networkQualityProgressFromGRPC(event *daemon.NetworkQualityTestProgress) *NetworkQualityProgress {
+	return &NetworkQualityProgress{
+		Phase:                    event.Phase,
+		DownloadCapacity:         event.DownloadCapacity,
+		UploadCapacity:           event.UploadCapacity,
+		DownloadRPM:              event.DownloadRPM,
+		UploadRPM:                event.UploadRPM,
+		IdleLatencyMs:            event.IdleLatencyMs,
+		ElapsedMs:                event.ElapsedMs,
+		IsFinal:                  event.IsFinal,
+		Error:                    event.Error,
+		DownloadCapacityAccuracy: event.DownloadCapacityAccuracy,
+		UploadCapacityAccuracy:   event.UploadCapacityAccuracy,
+		DownloadRPMAccuracy:      event.DownloadRPMAccuracy,
+		UploadRPMAccuracy:        event.UploadRPMAccuracy,
+	}
+}

--- a/experimental/libbox/networkquality.go
+++ b/experimental/libbox/networkquality.go
@@ -1,0 +1,75 @@
+package libbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/sagernet/sing-box/common/networkquality"
+)
+
+type NetworkQualityTest struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewNetworkQualityTest() *NetworkQualityTest {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &NetworkQualityTest{ctx: ctx, cancel: cancel}
+}
+
+func (t *NetworkQualityTest) Start(configURL string, handler NetworkQualityTestHandler) {
+	t.StartWithSerialAndRuntime(configURL, false, NetworkQualityDefaultMaxRuntimeSeconds, handler)
+}
+
+func (t *NetworkQualityTest) StartWithSerial(configURL string, serial bool, handler NetworkQualityTestHandler) {
+	t.StartWithSerialAndRuntime(configURL, serial, NetworkQualityDefaultMaxRuntimeSeconds, handler)
+}
+
+func (t *NetworkQualityTest) StartWithSerialAndRuntime(configURL string, serial bool, maxRuntimeSeconds int32, handler NetworkQualityTestHandler) {
+	go func() {
+		httpClient := networkquality.NewHTTPClient(nil)
+		defer httpClient.CloseIdleConnections()
+
+		result, err := networkquality.Run(networkquality.Options{
+			ConfigURL:  configURL,
+			HTTPClient: httpClient,
+			Serial:     serial,
+			MaxRuntime: time.Duration(maxRuntimeSeconds) * time.Second,
+			Context:    t.ctx,
+			OnProgress: func(p networkquality.Progress) {
+				handler.OnProgress(&NetworkQualityProgress{
+					Phase:                    int32(p.Phase),
+					DownloadCapacity:         p.DownloadCapacity,
+					UploadCapacity:           p.UploadCapacity,
+					DownloadRPM:              p.DownloadRPM,
+					UploadRPM:                p.UploadRPM,
+					IdleLatencyMs:            p.IdleLatencyMs,
+					ElapsedMs:                p.ElapsedMs,
+					DownloadCapacityAccuracy: int32(p.DownloadCapacityAccuracy),
+					UploadCapacityAccuracy:   int32(p.UploadCapacityAccuracy),
+					DownloadRPMAccuracy:      int32(p.DownloadRPMAccuracy),
+					UploadRPMAccuracy:        int32(p.UploadRPMAccuracy),
+				})
+			},
+		})
+		if err != nil {
+			handler.OnError(err.Error())
+			return
+		}
+		handler.OnResult(&NetworkQualityResult{
+			DownloadCapacity:         result.DownloadCapacity,
+			UploadCapacity:           result.UploadCapacity,
+			DownloadRPM:              result.DownloadRPM,
+			UploadRPM:                result.UploadRPM,
+			IdleLatencyMs:            result.IdleLatencyMs,
+			DownloadCapacityAccuracy: int32(result.DownloadCapacityAccuracy),
+			UploadCapacityAccuracy:   int32(result.UploadCapacityAccuracy),
+			DownloadRPMAccuracy:      int32(result.DownloadRPMAccuracy),
+			UploadRPMAccuracy:        int32(result.UploadRPMAccuracy),
+		})
+	}()
+}
+
+func (t *NetworkQualityTest) Cancel() {
+	t.cancel()
+}

--- a/experimental/libbox/setup.go
+++ b/experimental/libbox/setup.go
@@ -1,6 +1,7 @@
 package libbox
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sagernet/sing-box/common/networkquality"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/experimental/locale"
 	"github.com/sagernet/sing-box/log"
@@ -128,6 +130,29 @@ func FormatMemoryBytes(length int64) string {
 func FormatDuration(duration int64) string {
 	return log.FormatDuration(time.Duration(duration) * time.Millisecond)
 }
+
+func FormatBitrate(bps int64) string {
+	switch {
+	case bps >= 1_000_000_000:
+		return fmt.Sprintf("%.1f Gbps", float64(bps)/1_000_000_000)
+	case bps >= 1_000_000:
+		return fmt.Sprintf("%.1f Mbps", float64(bps)/1_000_000)
+	case bps >= 1_000:
+		return fmt.Sprintf("%.1f Kbps", float64(bps)/1_000)
+	default:
+		return fmt.Sprintf("%d bps", bps)
+	}
+}
+
+const NetworkQualityDefaultConfigURL = networkquality.DefaultConfigURL
+
+const NetworkQualityDefaultMaxRuntimeSeconds = int32(networkquality.DefaultMaxRuntime / time.Second)
+
+const (
+	NetworkQualityAccuracyLow    = int32(networkquality.AccuracyLow)
+	NetworkQualityAccuracyMedium = int32(networkquality.AccuracyMedium)
+	NetworkQualityAccuracyHigh   = int32(networkquality.AccuracyHigh)
+)
 
 func ProxyDisplayType(proxyType string) string {
 	return C.ProxyDisplayName(proxyType)

--- a/option/rule.go
+++ b/option/rule.go
@@ -91,6 +91,7 @@ type RawDefaultRule struct {
 	ProcessPath              badoption.Listable[string]                                                  `json:"process_path,omitempty"`
 	ProcessPathRegex         badoption.Listable[string]                                                  `json:"process_path_regex,omitempty"`
 	PackageName              badoption.Listable[string]                                                  `json:"package_name,omitempty"`
+	PackageNameRegex         badoption.Listable[string]                                                  `json:"package_name_regex,omitempty"`
 	User                     badoption.Listable[string]                                                  `json:"user,omitempty"`
 	UserID                   badoption.Listable[int32]                                                   `json:"user_id,omitempty"`
 	ClashMode                string                                                                      `json:"clash_mode,omitempty"`

--- a/option/rule_dns.go
+++ b/option/rule_dns.go
@@ -88,6 +88,7 @@ type RawDefaultDNSRule struct {
 	ProcessPath              badoption.Listable[string]                                                  `json:"process_path,omitempty"`
 	ProcessPathRegex         badoption.Listable[string]                                                  `json:"process_path_regex,omitempty"`
 	PackageName              badoption.Listable[string]                                                  `json:"package_name,omitempty"`
+	PackageNameRegex         badoption.Listable[string]                                                  `json:"package_name_regex,omitempty"`
 	User                     badoption.Listable[string]                                                  `json:"user,omitempty"`
 	UserID                   badoption.Listable[int32]                                                   `json:"user_id,omitempty"`
 	Outbound                 badoption.Listable[string]                                                  `json:"outbound,omitempty"`

--- a/option/rule_set.go
+++ b/option/rule_set.go
@@ -198,6 +198,7 @@ type DefaultHeadlessRule struct {
 	ProcessPath             badoption.Listable[string]                                                  `json:"process_path,omitempty"`
 	ProcessPathRegex        badoption.Listable[string]                                                  `json:"process_path_regex,omitempty"`
 	PackageName             badoption.Listable[string]                                                  `json:"package_name,omitempty"`
+	PackageNameRegex        badoption.Listable[string]                                                  `json:"package_name_regex,omitempty"`
 	NetworkType             badoption.Listable[InterfaceType]                                           `json:"network_type,omitempty"`
 	NetworkIsExpensive      bool                                                                        `json:"network_is_expensive,omitempty"`
 	NetworkIsConstrained    bool                                                                        `json:"network_is_constrained,omitempty"`
@@ -243,7 +244,7 @@ type PlainRuleSetCompat _PlainRuleSetCompat
 func (r PlainRuleSetCompat) MarshalJSON() ([]byte, error) {
 	var v any
 	switch r.Version {
-	case C.RuleSetVersion1, C.RuleSetVersion2, C.RuleSetVersion3, C.RuleSetVersion4:
+	case C.RuleSetVersion1, C.RuleSetVersion2, C.RuleSetVersion3, C.RuleSetVersion4, C.RuleSetVersion5:
 		v = r.Options
 	default:
 		return nil, E.New("unknown rule-set version: ", r.Version)
@@ -258,7 +259,7 @@ func (r *PlainRuleSetCompat) UnmarshalJSON(bytes []byte) error {
 	}
 	var v any
 	switch r.Version {
-	case C.RuleSetVersion1, C.RuleSetVersion2, C.RuleSetVersion3, C.RuleSetVersion4:
+	case C.RuleSetVersion1, C.RuleSetVersion2, C.RuleSetVersion3, C.RuleSetVersion4, C.RuleSetVersion5:
 		v = &r.Options
 	case 0:
 		return E.New("missing rule-set version")
@@ -275,7 +276,7 @@ func (r *PlainRuleSetCompat) UnmarshalJSON(bytes []byte) error {
 
 func (r PlainRuleSetCompat) Upgrade() (PlainRuleSet, error) {
 	switch r.Version {
-	case C.RuleSetVersion1, C.RuleSetVersion2, C.RuleSetVersion3, C.RuleSetVersion4:
+	case C.RuleSetVersion1, C.RuleSetVersion2, C.RuleSetVersion3, C.RuleSetVersion4, C.RuleSetVersion5:
 	default:
 		return PlainRuleSet{}, E.New("unknown rule-set version: " + F.ToString(r.Version))
 	}

--- a/route/rule/rule_default.go
+++ b/route/rule/rule_default.go
@@ -209,6 +209,14 @@ func NewDefaultRule(ctx context.Context, logger log.ContextLogger, options optio
 		rule.items = append(rule.items, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.PackageNameRegex) > 0 {
+		item, err := NewPackageNameRegexItem(options.PackageNameRegex)
+		if err != nil {
+			return nil, E.Cause(err, "package_name_regex")
+		}
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.User) > 0 {
 		item := NewUserItem(options.User)
 		rule.items = append(rule.items, item)

--- a/route/rule/rule_dns.go
+++ b/route/rule/rule_dns.go
@@ -256,6 +256,14 @@ func NewDefaultDNSRule(ctx context.Context, logger log.ContextLogger, options op
 		rule.items = append(rule.items, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.PackageNameRegex) > 0 {
+		item, err := NewPackageNameRegexItem(options.PackageNameRegex)
+		if err != nil {
+			return nil, E.Cause(err, "package_name_regex")
+		}
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if len(options.User) > 0 {
 		item := NewUserItem(options.User)
 		rule.items = append(rule.items, item)

--- a/route/rule/rule_headless.go
+++ b/route/rule/rule_headless.go
@@ -153,6 +153,14 @@ func NewDefaultHeadlessRule(ctx context.Context, options option.DefaultHeadlessR
 		rule.items = append(rule.items, item)
 		rule.allItems = append(rule.allItems, item)
 	}
+	if len(options.PackageNameRegex) > 0 {
+		item, err := NewPackageNameRegexItem(options.PackageNameRegex)
+		if err != nil {
+			return nil, E.Cause(err, "package_name_regex")
+		}
+		rule.items = append(rule.items, item)
+		rule.allItems = append(rule.allItems, item)
+	}
 	if networkManager != nil {
 		if len(options.NetworkType) > 0 {
 			item := NewNetworkTypeItem(networkManager, common.Map(options.NetworkType, option.InterfaceType.Build))

--- a/route/rule/rule_item_package_name_regex.go
+++ b/route/rule/rule_item_package_name_regex.go
@@ -1,0 +1,56 @@
+package rule
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+)
+
+var _ RuleItem = (*PackageNameRegexItem)(nil)
+
+type PackageNameRegexItem struct {
+	matchers    []*regexp.Regexp
+	description string
+}
+
+func NewPackageNameRegexItem(expressions []string) (*PackageNameRegexItem, error) {
+	matchers := make([]*regexp.Regexp, 0, len(expressions))
+	for i, regex := range expressions {
+		matcher, err := regexp.Compile(regex)
+		if err != nil {
+			return nil, E.Cause(err, "parse expression ", i)
+		}
+		matchers = append(matchers, matcher)
+	}
+	description := "package_name_regex="
+	eLen := len(expressions)
+	if eLen == 1 {
+		description += expressions[0]
+	} else if eLen > 3 {
+		description += F.ToString("[", strings.Join(expressions[:3], " "), "]")
+	} else {
+		description += F.ToString("[", strings.Join(expressions, " "), "]")
+	}
+	return &PackageNameRegexItem{matchers, description}, nil
+}
+
+func (r *PackageNameRegexItem) Match(metadata *adapter.InboundContext) bool {
+	if metadata.ProcessInfo == nil || len(metadata.ProcessInfo.AndroidPackageNames) == 0 {
+		return false
+	}
+	for _, packageName := range metadata.ProcessInfo.AndroidPackageNames {
+		for _, matcher := range r.matchers {
+			if matcher.MatchString(packageName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (r *PackageNameRegexItem) String() string {
+	return r.description
+}

--- a/route/rule/rule_set.go
+++ b/route/rule/rule_set.go
@@ -60,7 +60,7 @@ func HasHeadlessRule(rules []option.HeadlessRule, cond func(rule option.DefaultH
 }
 
 func isProcessHeadlessRule(rule option.DefaultHeadlessRule) bool {
-	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0
+	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0 || len(rule.PackageNameRegex) > 0
 }
 
 func isWIFIHeadlessRule(rule option.DefaultHeadlessRule) bool {

--- a/route/rule_conds.go
+++ b/route/rule_conds.go
@@ -38,11 +38,11 @@ func hasDNSRule(rules []option.DNSRule, cond func(rule option.DefaultDNSRule) bo
 }
 
 func isProcessRule(rule option.DefaultRule) bool {
-	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0 || len(rule.User) > 0 || len(rule.UserID) > 0
+	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0 || len(rule.PackageNameRegex) > 0 || len(rule.User) > 0 || len(rule.UserID) > 0
 }
 
 func isProcessDNSRule(rule option.DefaultDNSRule) bool {
-	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0 || len(rule.User) > 0 || len(rule.UserID) > 0
+	return len(rule.ProcessName) > 0 || len(rule.ProcessPath) > 0 || len(rule.ProcessPathRegex) > 0 || len(rule.PackageName) > 0 || len(rule.PackageNameRegex) > 0 || len(rule.User) > 0 || len(rule.UserID) > 0
 }
 
 func isNeighborRule(rule option.DefaultRule) bool {


### PR DESCRIPTION
Closes #4009

Adds `package_name_regex` — regex matching for Android package names, analogous to the existing `process_path_regex` for process paths.

Supported in all rule types: route rules, DNS rules, and headless rules (rule sets), as requested.

When combined with `invert`, this allows matching connections where the package name could not be determined:

```json
{"package_name_regex": [".*"], "invert": true, "outbound": "block"}
```

Changes:
- New matcher in `route/rule/rule_item_package_name_regex.go`
- Rule set binary format bumped to version 5 with backward-compatible downgrade
- Documentation updated (EN/ZH) for route rules, DNS rules, headless rules, feature matrices, and rule set source format

**Note:** I did not add "Since sing-box ..." / "Changes in sing-box ..." version markers in the documentation because I don't know which release this will land in. Happy to update if you prefer a specific version.