### PR TITLE
fix: skip respond for no-evaluated exchange

### DIFF
--- a/dns/router.go
+++ b/dns/router.go
@@ -445,9 +445,7 @@ func (r *Router) exchangeWithRules(ctx context.Context, rules []adapter.DNSRule,
 			evaluatedTransport = transport
 		case *R.RuleActionRespond:
 			if evaluatedResponse == nil {
-				return exchangeWithRulesResult{
-					err: E.New(dnsRespondMissingResponseMessage),
-				}
+				continue
 			}
 			return exchangeWithRulesResult{
 				response:  evaluatedResponse,


### PR DESCRIPTION
为未被 evaluate 评估过的请求跳过 respond 动作，避免因 exchange 失败的评估动作导致的 respond 动作报错