### PR TITLE
Fix network initialization during system boot

### DIFF
--- a/route/network.go
+++ b/route/network.go
@@ -479,7 +479,7 @@ func (r *NetworkManager) ResetNetwork() {
 }
 
 func (r *NetworkManager) notifyInterfaceUpdate(defaultInterface *control.Interface, flags int) {
-	if defaultInterface == nil {
+	if defaultInterface == nil && r.started {
 		r.pauseManager.NetworkPause()
 		r.logger.Error("missing default interface")
 		return


### PR DESCRIPTION
During Linux system boot, the network stack may not be fully initialized when sing-box starts. The original code would trigger `NetworkPause()` for missing default interface, preventing automatic recovery after network initialization completes.

Skip pause handling when not started to allow proper initialization.