### PR TITLE
fix(dns): add timeout context for DBus checkResolved calls

### DIFF
--- a/dns/transport/local/local_resolved_linux.go
+++ b/dns/transport/local/local_resolved_linux.go
@@ -138,7 +138,9 @@ func (t *DBusResolvedResolver) Exchange(ctx context.Context, message *mDNS.Msg) 
 	serverSet := t.savedServerSet.Load()
 	if serverSet == nil {
 		var err error
-		serverSet, err = t.checkResolved(context.Background())
+		checkCtx, checkCancel := context.WithTimeout(context.Background(), C.DNSTimeout)
+		defer checkCancel()
+		serverSet, err = t.checkResolved(checkCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -183,7 +185,9 @@ func (t *DBusResolvedResolver) loopUpdateStatus() {
 }
 
 func (t *DBusResolvedResolver) updateStatus() {
-	serverSet, err := t.checkResolved(context.Background())
+	checkCtx, checkCancel := context.WithTimeout(context.Background(), C.DNSTimeout)
+	defer checkCancel()
+	serverSet, err := t.checkResolved(checkCtx)
 	oldServerSet := t.savedServerSet.Swap(serverSet)
 	if oldServerSet != nil {
 		_ = oldServerSet.Close()


### PR DESCRIPTION
## Description

The \checkResolved\ method in \local_resolved_linux.go\ was called with \context.Background()\ from both \Exchange()\ and \updateStatus()\, passing it into \CallWithContext()\ for DBus operations. This meant there was no application-level timeout or cancellation mechanism.

## Fix

Wrap the context with \context.WithTimeout\ using \C.DNSTimeout\ (10s) before passing to \checkResolved()\. If the DBus operation hangs, the timeout ensures the call returns instead of blocking indefinitely.

## Related Issue

Fixes #4160