### PR TITLE
fix(route): prevent use-after-close race on PacketConn in sniffing loop

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -726,6 +726,7 @@ func (r *Router) actionSniff(
 			case <-done:
 			case <-ctx.Done():
 				inputPacketConn.Close()
+				<-done
 				fatalErr = ctx.Err()
 				return
 			}


### PR DESCRIPTION
## Description

In \oute/route.go:709-768\, the packet sniffing loop spawns a goroutine that calls \SetReadDeadline()\ and \ReadPacket()\ on \inputPacketConn\. When \ctx.Done()\ fires, the main goroutine calls \inputPacketConn.Close()\ at line 728 while the goroutine may still be using the connection.

## Fix

Wait for the goroutine to finish (\<-done\) after closing \inputPacketConn\. Since \Close()\ unblocks \ReadPacket()\, the goroutine will return quickly and the connection won't be used after close.

## Related Issue

Fixes #4161