### PR TITLE
fix(libbox): prevent goroutine leak in ExchangeContext.OnCancel

### DIFF
--- a/experimental/libbox/dns.go
+++ b/experimental/libbox/dns.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/sagernet/sing-box/adapter"
 	C "github.com/sagernet/sing-box/constant"
@@ -121,8 +122,11 @@ type ExchangeContext struct {
 
 func (c *ExchangeContext) OnCancel(callback Func) {
 	go func() {
-		<-c.context.Done()
-		callback.Invoke()
+		select {
+		case <-c.context.Done():
+			callback.Invoke()
+		case <-time.After(C.DNSTimeout):
+		}
 	}()
 }
 


### PR DESCRIPTION
## Description

\ExchangeContext.OnCancel()\ at \experimental/libbox/dns.go:122-127\ spawns a goroutine that blocks on \c.context.Done()\. If the context passed to \Exchange()\ is never cancelled (e.g., caller does not set a deadline or cancellation), the goroutine leaks indefinitely.

## Fix

Add a \select\ with \	ime.After(C.DNSTimeout)\ as a fallback to ensure the goroutine terminates even if the context is never done.

## Related Issue

Fixes #4162