### PR TITLE
fix(hysteria2): check json.Marshal error in SSE event stream

### DIFF
--- a/protocol/hysteria2/realm_server.go
+++ b/protocol/hysteria2/realm_server.go
@@ -380,7 +380,11 @@ func (s *server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			if !open {
 				return
 			}
-			data, _ := json.Marshal(ev.data)
+			data, err := json.Marshal(ev.data)
+			if err != nil {
+				s.logger.Error("marshal event: ", err)
+				continue
+			}
 			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.kind, data)
 			flusher.Flush()
 		}


### PR DESCRIPTION
## Description

In \protocol/hysteria2/realm_server.go:383\, the error from \json.Marshal\ is silently discarded with \data, _ := json.Marshal(ev.data)\. If \ev.data\ contains values that cannot be serialized (e.g., cyclic structures), the SSE stream sends empty data with no error logged.

## Fix

Check the error from \json.Marshal\, log it, and skip the event to avoid sending corrupted data.

## Related Issue

Fixes #4163