### PR TITLE
Refine http Proxy-Authenticate basic auth workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,3 +177,5 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 	zombiezen.com/go/capnproto2 v2.18.2+incompatible // indirect
 )
+
+replace github.com/sagernet/sing => github.com/tianhuyang/sing v0.8.11-0.20260623101140-6c597e4bf541

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,6 @@ github.com/sagernet/nftables v0.3.0-mod.2 h1:ck2KMU02OxL1eDFgGaWYglMDpoOZ7OHzxje
 github.com/sagernet/nftables v0.3.0-mod.2/go.mod h1:8kslHG4VvYNihcco+i6uxIX7qbT8A56T0y5q7U44ZaQ=
 github.com/sagernet/quic-go v0.59.0-sing-box-mod.4 h1:6qvrUW79S+CrPwWz6cMePXohgjHoKxLo3c+MDhNwc3o=
 github.com/sagernet/quic-go v0.59.0-sing-box-mod.4/go.mod h1:OqILvS182CyOol5zNNo6bguvOGgXzV459+chpRaUC+4=
-github.com/sagernet/sing v0.8.11-0.20260514110501-905ad103a4df h1:zSDw1g1JhIEqE/XPC3hW1wMdFPzbVgVJZiV86FAJoNQ=
-github.com/sagernet/sing v0.8.11-0.20260514110501-905ad103a4df/go.mod h1:olXxWQNqRW/l2Q6JI3b2Qmz8iQnIFlOeeH8bx6JhgUA=
 github.com/sagernet/sing-cloudflared v0.1.1-0.20260620151903-a1d6358fe953 h1:bqZWzc7mVO+V6Z07PAwav1TnlAlNltr/e1J2z8sZn4o=
 github.com/sagernet/sing-cloudflared v0.1.1-0.20260620151903-a1d6358fe953/go.mod h1:bH2NKX+NpDTY1Zkxfboxw6MXB/ZywaNLmrDJYgKMJ2Y=
 github.com/sagernet/sing-mux v0.3.5 h1:RHnhVEc+SFqkrK4xMygYjDwwLhzp2Bj3lztSukONfhI=
@@ -304,6 +302,8 @@ github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:U
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=
 github.com/tc-hib/winres v0.2.1/go.mod h1:C/JaNhH3KBvhNKVbvdlDWkbMDO9H4fKKDaN7/07SSuk=
+github.com/tianhuyang/sing v0.8.11-0.20260623101140-6c597e4bf541 h1:xmf4mAE98yHyfF6gfIjtwelsvwhs7nGNhG1V8D0ASRI=
+github.com/tianhuyang/sing v0.8.11-0.20260623101140-6c597e4bf541/go.mod h1:olXxWQNqRW/l2Q6JI3b2Qmz8iQnIFlOeeH8bx6JhgUA=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/protocol/http/inbound.go
+++ b/protocol/http/inbound.go
@@ -96,7 +96,16 @@ func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata ada
 		}
 		conn = tlsConn
 	}
-	err := http.HandleConnectionEx(ctx, conn, std_bufio.NewReader(conn), h.authenticator, adapter.NewUpstreamHandler(metadata, h.newUserConnection, h.streamUserPacketConnection), metadata.Source, onClose)
+	err := http.HandleConnectionExWithOptions(
+		ctx,
+		conn,
+		std_bufio.NewReader(conn),
+		h.authenticator,
+		adapter.NewUpstreamHandler(metadata, h.newUserConnection, h.streamUserPacketConnection),
+		metadata.Source,
+		onClose,
+		http.HTTPServerOptions{Logger: h.logger},
+	)
 	if err != nil {
 		N.CloseOnHandshakeFailure(conn, onClose, err)
 		h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source))

--- a/protocol/mixed/inbound.go
+++ b/protocol/mixed/inbound.go
@@ -127,7 +127,16 @@ func (h *Inbound) newConnection(ctx context.Context, conn net.Conn, metadata ada
 	case socks4.Version, socks5.Version:
 		return socks.HandleConnectionEx(ctx, conn, reader, h.authenticator, adapter.NewUpstreamHandler(metadata, h.newUserConnection, h.streamUserPacketConnection), h.listener, h.udpTimeout, metadata.Source, onClose)
 	default:
-		return http.HandleConnectionEx(ctx, conn, reader, h.authenticator, adapter.NewUpstreamHandler(metadata, h.newUserConnection, h.streamUserPacketConnection), metadata.Source, onClose)
+		return http.HandleConnectionExWithOptions(
+			ctx,
+			conn,
+			reader,
+			h.authenticator,
+			adapter.NewUpstreamHandler(metadata, h.newUserConnection, h.streamUserPacketConnection),
+			metadata.Source,
+			onClose,
+			http.HTTPServerOptions{Logger: h.logger},
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary
- inject inbound logger into HTTP handshake options for HTTP and Mixed inbounds
- switch HTTP handshake call sites to the option-based entrypoint with `HTTPServerOptions{Logger: h.logger}`
- update module metadata (`go.mod` / `go.sum`) to match the dependency state used by this branch

## Changed Files
- go.mod
- go.sum
- protocol/http/inbound.go
- protocol/mixed/inbound.go

## Validation
- branch history squashed to one commit
- pushed force-with-lease to tianhuyang/sing-box:fix/http-proxy-auth-retry

## Reference
- https://github.com/SagerNet/sing/pull/103
