### PR TITLE
ssmapi: Extend SSM API to all multi-user inbounds

### DIFF
--- a/adapter/router.go
+++ b/adapter/router.go
@@ -17,7 +17,7 @@ import (
 type Router interface {
 	Lifecycle
 	ConnectionRouter
-	PreMatch(metadata InboundContext) PreMatchResult
+	PreMatch(metadata InboundContext, firstPacket []byte) PreMatchResult
 	ConnectionRouterEx
 	RuleSet(tag string) (RuleSet, bool)
 	Rules() []Rule
@@ -42,9 +42,10 @@ type PreMatchResult struct {
 	Action      PreMatchAction
 	Outbound    Outbound
 	Destination netip.AddrPort
+	NewTracker  func() tun.FlowTracker
 }
 
-func JudgeFlow(router Router, inbound string, inboundType string, network uint8, source netip.AddrPort, destination netip.AddrPort) tun.FlowVerdict {
+func JudgeFlow(router Router, inbound string, inboundType string, network uint8, source netip.AddrPort, destination netip.AddrPort, firstPacket []byte) tun.FlowVerdict {
 	var networkName string
 	switch network {
 	case uint8(header.TCPProtocolNumber):
@@ -67,14 +68,14 @@ func JudgeFlow(router Router, inbound string, inboundType string, network uint8,
 		metadata.Source.Port = 0
 		metadata.Destination.Port = 0
 	}
-	result := router.PreMatch(metadata)
+	result := router.PreMatch(metadata, firstPacket)
 	switch result.Action {
 	case PreMatchFlow:
 		port, isPort := result.Outbound.(tun.Port)
 		if !isPort {
 			return tun.FlowVerdict{Action: tun.ActionAccept}
 		}
-		verdict := tun.FlowVerdict{Action: tun.ActionFlow, Port: port}
+		verdict := tun.FlowVerdict{Action: tun.ActionFlow, Port: port, NewTracker: result.NewTracker}
 		if result.Destination.IsValid() {
 			destinationPort := result.Destination.Port()
 			if networkName == N.NetworkICMP {
@@ -97,6 +98,7 @@ func JudgeFlow(router Router, inbound string, inboundType string, network uint8,
 type ConnectionTracker interface {
 	RoutedConnection(ctx context.Context, conn net.Conn, metadata InboundContext, matchedRule Rule, matchOutbound Outbound) net.Conn
 	RoutedPacketConnection(ctx context.Context, conn N.PacketConn, metadata InboundContext, matchedRule Rule, matchOutbound Outbound) N.PacketConn
+	RoutedFlow(ctx context.Context, metadata InboundContext, matchedRule Rule, matchOutbound Outbound) tun.FlowTracker
 }
 
 // Deprecated: Use ConnectionRouterEx instead.

--- a/common/trafficcontrol/tracker.go
+++ b/common/trafficcontrol/tracker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/bufio"
 	N "github.com/sagernet/sing/common/network"
@@ -66,6 +67,13 @@ func (m *Manager) RoutedPacketConnection(ctx context.Context, conn N.PacketConn,
 	}
 	m.join(tracker)
 	return tracker
+}
+
+func (m *Manager) RoutedFlow(ctx context.Context, metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) tun.FlowTracker {
+	return &flowTracker{
+		metadata: m.newTrackerMetadata(metadata, matchedRule, matchOutbound, new(atomic.Int64), new(atomic.Int64)),
+		manager:  m,
+	}
 }
 
 func (m *Manager) newTrackerMetadata(metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound, upload *atomic.Int64, download *atomic.Int64) TrackerMetadata {
@@ -133,6 +141,53 @@ func (t *connTracker) ReaderReplaceable() bool {
 
 func (t *connTracker) WriterReplaceable() bool {
 	return true
+}
+
+var (
+	_ Tracker         = (*flowTracker)(nil)
+	_ tun.FlowTracker = (*flowTracker)(nil)
+)
+
+type flowTracker struct {
+	metadata TrackerMetadata
+	manager  *Manager
+	handle   tun.FlowHandle
+}
+
+func (t *flowTracker) Metadata() *TrackerMetadata {
+	return &t.metadata
+}
+
+func (t *flowTracker) AttachFlow(handle tun.FlowHandle) {
+	t.handle = handle
+	t.manager.join(t)
+}
+
+func (t *flowTracker) CountForward(n int) {
+	t.metadata.Upload.Add(int64(n))
+	t.manager.uploadTotal.Add(int64(n))
+}
+
+func (t *flowTracker) CountReverse(n int) {
+	t.metadata.Download.Add(int64(n))
+	t.manager.downloadTotal.Add(int64(n))
+}
+
+func (t *flowTracker) FlowEstablished() {
+}
+
+func (t *flowTracker) CloseFlow(reason tun.FlowCloseReason) {
+	t.manager.leave(t)
+}
+
+func (t *flowTracker) Close() error {
+	handle := t.handle
+	if handle != nil {
+		handle.CloseFlow()
+	} else {
+		t.manager.leave(t)
+	}
+	return nil
 }
 
 type packetConnTracker struct {

--- a/daemon/started_service.go
+++ b/daemon/started_service.go
@@ -986,8 +986,13 @@ func (s *StartedService) CloseAllConnections(ctx context.Context, empty *emptypb
 	s.serviceAccess.RLock()
 	nowService := s.instance
 	s.serviceAccess.RUnlock()
-	if nowService != nil && nowService.connectionManager != nil {
-		nowService.connectionManager.CloseAll()
+	if nowService != nil {
+		if nowService.connectionManager != nil {
+			nowService.connectionManager.CloseAll()
+		}
+		if nowService.trafficManager != nil {
+			nowService.trafficManager.CloseAllConnections()
+		}
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/docs/configuration/service/ssm-api.md
+++ b/docs/configuration/service/ssm-api.md
@@ -2,11 +2,15 @@
 icon: material/new-box
 ---
 
+!!! quote "Changes in sing-box 1.14.0"
+
+    :material-alert-decagram: [servers](#servers)
+
 !!! question "Since sing-box 1.12.0"
 
 # SSM API
 
-SSM API service is a RESTful API server for managing Shadowsocks servers.
+SSM API service is a RESTful API server for managing multi-user inbounds.
 
 See https://github.com/Shadowsocks-NET/shadowsocks-specs/blob/main/2023-1-shadowsocks-server-management-api-v1.md
 
@@ -34,9 +38,28 @@ See [Listen Fields](/configuration/shared/listen/) for details.
 
 ==Required==
 
-A mapping Object from HTTP endpoints to [Shadowsocks Inbound](/configuration/inbound/shadowsocks) tags.
+A mapping Object from HTTP endpoints to inbound tags.
+
+Supported inbounds:
+
+* [Shadowsocks](/configuration/inbound/shadowsocks) (multi-user)
+* [HTTP](/configuration/inbound/http)
+* [Mixed](/configuration/inbound/mixed)
+* [SOCKS](/configuration/inbound/socks)
+* [Naive](/configuration/inbound/naive)
+* [Trojan](/configuration/inbound/trojan)
+* [VMess](/configuration/inbound/vmess)
+* [AnyTLS](/configuration/inbound/anytls)
+* [Hysteria](/configuration/inbound/hysteria)
+* [Hysteria2](/configuration/inbound/hysteria2)
 
 Selected Shadowsocks inbounds must be configured with [managed](/configuration/inbound/shadowsocks#managed) enabled.
+
+Since the SSM API user object carries a single credential, for VMess inbounds
+the user password is the UUID, and managed users always use `alterId` `0`.
+
+VLESS and TUIC inbounds are not supported, as their users cannot be
+represented by a single credential (`flow` and `uuid` + `password` respectively).
 
 Example:
 

--- a/docs/configuration/service/ssm-api.zh.md
+++ b/docs/configuration/service/ssm-api.zh.md
@@ -2,11 +2,15 @@
 icon: material/new-box
 ---
 
+!!! quote "sing-box 1.14.0 中的更改"
+
+    :material-alert-decagram: [servers](#servers)
+
 !!! question "自 sing-box 1.12.0 起"
 
 # SSM API
 
-SSM API 服务是一个用于管理 Shadowsocks 服务器的 RESTful API 服务器。
+SSM API 服务是一个用于管理多用户入站的 RESTful API 服务器。
 
 参阅 https://github.com/Shadowsocks-NET/shadowsocks-specs/blob/main/2023-1-shadowsocks-server-management-api-v1.md
 
@@ -34,9 +38,26 @@ SSM API 服务是一个用于管理 Shadowsocks 服务器的 RESTful API 服务�
 
 ==必填==
 
-从 HTTP 端点到 [Shadowsocks 入站](/zh/configuration/inbound/shadowsocks) 标签的映射对象。
+从 HTTP 端点到入站标签的映射对象。
+
+支持的入站：
+
+* [Shadowsocks](/zh/configuration/inbound/shadowsocks)（多用户）
+* [HTTP](/zh/configuration/inbound/http)
+* [Mixed](/zh/configuration/inbound/mixed)
+* [SOCKS](/zh/configuration/inbound/socks)
+* [Naive](/zh/configuration/inbound/naive)
+* [Trojan](/zh/configuration/inbound/trojan)
+* [VMess](/zh/configuration/inbound/vmess)
+* [AnyTLS](/zh/configuration/inbound/anytls)
+* [Hysteria](/zh/configuration/inbound/hysteria)
+* [Hysteria2](/zh/configuration/inbound/hysteria2)
 
 选定的 Shadowsocks 入站必须配置启用 [managed](/zh/configuration/inbound/shadowsocks#managed)。
+
+由于 SSM API 用户对象仅包含单个凭据，对于 VMess 入站，用户密码即为 UUID，且受管理的用户始终使用 `alterId` `0`。
+
+不支持 VLESS 和 TUIC 入站，因为它们的用户无法用单个凭据表示（分别为 `flow` 和 `uuid` + `password`）。
 
 示例：
 

--- a/docs/configuration/shared/pre-match.md
+++ b/docs/configuration/shared/pre-match.md
@@ -6,7 +6,8 @@ icon: material/new-box
 
 !!! quote "Changes in sing-box 1.14.0"
 
-    :material-alert: [route](#route)
+    :material-alert: [route](#route)  
+    :material-plus: [sniff](#sniff)
 
 !!! quote "Changes in sing-box 1.13.0"
 
@@ -16,11 +17,11 @@ Pre-match is rule matching that runs before the connection is established.
 
 ### How it works
 
-When an L3 inbound (TUN, WireGuard, or Tailscale) receives a connection request, the connection has not yet been established,
-so no connection data can be read. In this phase, sing-box runs the routing rules in pre-match mode.
+When an L3 inbound (TUN, WireGuard, or Tailscale) receives a connection request, the connection has not yet been established:
+for TCP connections no connection data is available, while for UDP connections only the first packet is available.
+In this phase, sing-box runs the routing rules in pre-match mode.
 
-Since connection data is unavailable, only actions that do not require connection data can be executed.
-When a rule matches an action that requires an established connection, pre-match stops at that rule.
+When a rule matches an action that requires more connection data than available, pre-match stops at that rule.
 
 ### Supported actions
 
@@ -52,6 +53,19 @@ FakeIP destinations require a `resolve` action performed in pre-match,
 otherwise connections will be rejected.
 
 See [route](/configuration/route/rule_action/#route) for details.
+
+#### sniff
+
+!!! question "Since sing-box 1.14.0"
+
+For UDP connections, the first packet is available in pre-match,
+so protocol sniffing runs on it directly and rule matching continues with the sniffed metadata.
+
+When sniffers require more data (like a fragmented QUIC Client Hello), pre-match stops at that rule.
+
+For TCP connections, pre-match always stops at that rule.
+
+See [sniff](/configuration/route/rule_action/#sniff) for details.
 
 #### bypass
 

--- a/docs/configuration/shared/pre-match.zh.md
+++ b/docs/configuration/shared/pre-match.zh.md
@@ -6,7 +6,8 @@ icon: material/new-box
 
 !!! quote "sing-box 1.14.0 中的更改"
 
-    :material-alert: [route](#route)
+    :material-alert: [route](#route)  
+    :material-plus: [sniff](#sniff)
 
 !!! quote "sing-box 1.13.0 中的更改"
 
@@ -16,9 +17,9 @@ icon: material/new-box
 
 ### 工作原理
 
-当 L3 入站（TUN、WireGuard 或 Tailscale）收到连接请求时，连接尚未建立，因此无法读取连接数据。在此阶段，sing-box 在预匹配模式下运行路由规则。
+当 L3 入站（TUN、WireGuard 或 Tailscale）收到连接请求时，连接尚未建立：对于 TCP 连接，无连接数据可用；对于 UDP 连接，仅首个数据包可用。在此阶段，sing-box 在预匹配模式下运行路由规则。
 
-由于连接数据不可用，只有不需要连接数据的动作才能执行。当规则匹配到需要已建立连接的动作时，预匹配将在该规则处停止。
+当规则匹配到需要比当前可用数据更多连接数据的动作时，预匹配将在该规则处停止。
 
 ### 支持的动作
 
@@ -46,6 +47,18 @@ icon: material/new-box
 FakeIP 目标需要在预匹配中先执行 `resolve` 动作，否则连接将被拒绝。
 
 详情参阅 [route](/zh/configuration/route/rule_action/#route)。
+
+#### sniff
+
+!!! question "自 sing-box 1.14.0 起"
+
+对于 UDP 连接，首个数据包在预匹配中可用，因此协议探测将直接在其上运行，随后规则匹配将携带探测结果继续。
+
+当探测器需要更多数据时（如分片的 QUIC Client Hello），预匹配将在该规则处停止。
+
+对于 TCP 连接，预匹配总是在该规则处停止。
+
+详情参阅 [sniff](/zh/configuration/route/rule_action/#sniff)。
 
 #### bypass
 

--- a/experimental/v2rayapi/stats.go
+++ b/experimental/v2rayapi/stats.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common/bufio"
 	E "github.com/sagernet/sing/common/exceptions"
 	N "github.com/sagernet/sing/common/network"
@@ -116,6 +117,63 @@ func (s *StatsService) RoutedPacketConnection(ctx context.Context, conn N.Packet
 	}
 	s.access.Unlock()
 	return bufio.NewInt64CounterPacketConn(conn, readCounter, nil, writeCounter, nil)
+}
+
+func (s *StatsService) RoutedFlow(ctx context.Context, metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) tun.FlowTracker {
+	inbound := metadata.Inbound
+	user := metadata.User
+	outbound := matchOutbound.Tag()
+	var uplinkCounter []*atomic.Int64
+	var downlinkCounter []*atomic.Int64
+	countInbound := inbound != "" && s.inbounds[inbound]
+	countOutbound := outbound != "" && s.outbounds[outbound]
+	countUser := user != "" && s.users[user]
+	if !countInbound && !countOutbound && !countUser {
+		return nil
+	}
+	s.access.Lock()
+	if countInbound {
+		uplinkCounter = append(uplinkCounter, s.loadOrCreateCounter("inbound>>>"+inbound+">>>traffic>>>uplink"))
+		downlinkCounter = append(downlinkCounter, s.loadOrCreateCounter("inbound>>>"+inbound+">>>traffic>>>downlink"))
+	}
+	if countOutbound {
+		uplinkCounter = append(uplinkCounter, s.loadOrCreateCounter("outbound>>>"+outbound+">>>traffic>>>uplink"))
+		downlinkCounter = append(downlinkCounter, s.loadOrCreateCounter("outbound>>>"+outbound+">>>traffic>>>downlink"))
+	}
+	if countUser {
+		uplinkCounter = append(uplinkCounter, s.loadOrCreateCounter("user>>>"+user+">>>traffic>>>uplink"))
+		downlinkCounter = append(downlinkCounter, s.loadOrCreateCounter("user>>>"+user+">>>traffic>>>downlink"))
+	}
+	s.access.Unlock()
+	return &statsFlowTracker{uplinkCounter: uplinkCounter, downlinkCounter: downlinkCounter}
+}
+
+var _ tun.FlowTracker = (*statsFlowTracker)(nil)
+
+type statsFlowTracker struct {
+	uplinkCounter   []*atomic.Int64
+	downlinkCounter []*atomic.Int64
+}
+
+func (t *statsFlowTracker) AttachFlow(handle tun.FlowHandle) {
+}
+
+func (t *statsFlowTracker) CountForward(n int) {
+	for _, counter := range t.uplinkCounter {
+		counter.Add(int64(n))
+	}
+}
+
+func (t *statsFlowTracker) CountReverse(n int) {
+	for _, counter := range t.downlinkCounter {
+		counter.Add(int64(n))
+	}
+}
+
+func (t *statsFlowTracker) FlowEstablished() {
+}
+
+func (t *statsFlowTracker) CloseFlow(reason tun.FlowCloseReason) {
 }
 
 func (s *StatsService) GetStats(ctx context.Context, request *GetStatsRequest) (*GetStatsResponse, error) {

--- a/go.mod
+++ b/go.mod
@@ -49,12 +49,12 @@ require (
 	github.com/sagernet/sing-shadowsocks2 v0.2.1
 	github.com/sagernet/sing-shadowtls v0.2.1
 	github.com/sagernet/sing-snell v0.0.0-20260705044717-4e9e73be7814
-	github.com/sagernet/sing-tun v0.8.12-0.20260706130635-4b50856586ba
+	github.com/sagernet/sing-tun v0.8.12-0.20260706153816-c4a2d2afd8b5
 	github.com/sagernet/sing-usbip v0.0.0-20260616101517-efb91521eddb
 	github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1
 	github.com/sagernet/smux v1.5.50-sing-box-mod.1
 	github.com/sagernet/tailscale v1.92.4-sing-box-1.13-mod.7.0.20260706062137-ae2dde1295a3
-	github.com/sagernet/wireguard-go v0.0.5-0.20260706130655-57baac9504a8
+	github.com/sagernet/wireguard-go v0.0.5-0.20260706153856-2c27bbf4f97f
 	github.com/sagernet/ws v0.0.0-20231204124109-acfe8907c854
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/sagernet/sing-shadowtls v0.2.1 h1:ZiHZdnEnP+YS73NMsxiZmIFCwNd0M4k7PkG
 github.com/sagernet/sing-shadowtls v0.2.1/go.mod h1:sWqKnGlMipCHaGsw1sTTlimyUpgzP4WP3pjhCsYt9oA=
 github.com/sagernet/sing-snell v0.0.0-20260705044717-4e9e73be7814 h1:xfnkRpjVRVeJhVvDZA8PzTLlKGTb1o2kdI4uv1YymXo=
 github.com/sagernet/sing-snell v0.0.0-20260705044717-4e9e73be7814/go.mod h1:PcwzX/Xvqky0EP3kGt8OCjYb3R1pydenPHNQZcPZmXY=
-github.com/sagernet/sing-tun v0.8.12-0.20260706130635-4b50856586ba h1:/+QtKNDDJ6MEAIbmRWvnQSHNJHxXbtYTRX12xRY26Cg=
-github.com/sagernet/sing-tun v0.8.12-0.20260706130635-4b50856586ba/go.mod h1:QvarqUtHfj1ULaRR+6kZOS/OoCE+pYGq67A5tyIy+dQ=
+github.com/sagernet/sing-tun v0.8.12-0.20260706153816-c4a2d2afd8b5 h1:NKQ3ZWhUrWFqWLP1CxUFAX1e4/JOMMF2TbjkOYzJWj4=
+github.com/sagernet/sing-tun v0.8.12-0.20260706153816-c4a2d2afd8b5/go.mod h1:QvarqUtHfj1ULaRR+6kZOS/OoCE+pYGq67A5tyIy+dQ=
 github.com/sagernet/sing-usbip v0.0.0-20260616101517-efb91521eddb h1:KEMbfexD4DvrQGYWwx6r+AwH9Veh8z6cnBZmtCS2G+0=
 github.com/sagernet/sing-usbip v0.0.0-20260616101517-efb91521eddb/go.mod h1:D4CnJX3MNAAANhbQUxfIRgBdnvlTEaV7h6ojedcs+pw=
 github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1 h1:aSwUNYUkVyVvdmBSufR8/nRFonwJeKSIROxHcm5br9o=
@@ -284,8 +284,8 @@ github.com/sagernet/smux v1.5.50-sing-box-mod.1 h1:XkJcivBC9V4wBjiGXIXZ229aZCU1h
 github.com/sagernet/smux v1.5.50-sing-box-mod.1/go.mod h1:NjhsCEWedJm7eFLyhuBgIEzwfhRmytrUoiLluxs5Sk8=
 github.com/sagernet/tailscale v1.92.4-sing-box-1.13-mod.7.0.20260706062137-ae2dde1295a3 h1:eczvica8YiS5j3GfpHg6JG1Icur4Z2D6ffSrLZTfD1E=
 github.com/sagernet/tailscale v1.92.4-sing-box-1.13-mod.7.0.20260706062137-ae2dde1295a3/go.mod h1:p8Ms8FbGlwQJyHb862XmdShTS50fFJ8C71VdO6xvWyk=
-github.com/sagernet/wireguard-go v0.0.5-0.20260706130655-57baac9504a8 h1:gfukXANr9v5kcrKGeoCV5c+IdessM9NRGzWE7Aot9sw=
-github.com/sagernet/wireguard-go v0.0.5-0.20260706130655-57baac9504a8/go.mod h1:hEqi4y5czEg6LYtX2Bpjg+lV0b/J1n+5rA885Z66Mx0=
+github.com/sagernet/wireguard-go v0.0.5-0.20260706153856-2c27bbf4f97f h1:TzN97RL07xWb3gZtmqFhsdkud4f6G/pohiaOLiqSBj4=
+github.com/sagernet/wireguard-go v0.0.5-0.20260706153856-2c27bbf4f97f/go.mod h1:hEqi4y5czEg6LYtX2Bpjg+lV0b/J1n+5rA885Z66Mx0=
 github.com/sagernet/ws v0.0.0-20231204124109-acfe8907c854 h1:6uUiZcDRnZSAegryaUGwPC/Fj13JSHwiTftrXhMmYOc=
 github.com/sagernet/ws v0.0.0-20231204124109-acfe8907c854/go.mod h1:LtfoSK3+NG57tvnVEHgcuBW9ujgE8enPSgzgwStwCAA=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/protocol/anytls/inbound.go
+++ b/protocol/anytls/inbound.go
@@ -28,6 +28,8 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.AnyTLSInboundOptions](registry, C.TypeAnyTLS, NewInbound)
 }
 
+var _ adapter.ManagedSSMServer = (*Inbound)(nil)
+
 type Inbound struct {
 	inbound.Adapter
 	tlsConfig tls.ServerConfig
@@ -35,6 +37,7 @@ type Inbound struct {
 	logger    logger.ContextLogger
 	listener  *listener.Listener
 	service   *anytls.Service
+	tracker   adapter.SSMTracker
 }
 
 func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AnyTLSInboundOptions) (adapter.Inbound, error) {
@@ -96,6 +99,20 @@ func (h *Inbound) Close() error {
 	return common.Close(h.listener, h.tlsConfig)
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	h.service.UpdateUsers(common.MapIndexed(users, func(index int, user string) anytls.User {
+		return anytls.User{
+			Name:     user,
+			Password: uPSKs[index],
+		}
+	}))
+	return nil
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	if h.tlsConfig != nil {
 		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
@@ -127,6 +144,9 @@ func (h *inboundHandler) NewConnectionEx(ctx context.Context, conn net.Conn, sou
 	if userName, _ := auth.UserFromContext[string](ctx); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+		if h.tracker != nil {
+			conn = h.tracker.TrackConnection(conn, metadata)
+		}
 	} else {
 		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
 	}

--- a/protocol/cloudflare/inbound.go
+++ b/protocol/cloudflare/inbound.go
@@ -144,7 +144,7 @@ func (h *icmpRouterHandler) RouteICMPFlow(source netip.Addr, destination netip.A
 		Network:     N.NetworkICMP,
 		Source:      M.SocksaddrFrom(source, 0),
 		Destination: M.SocksaddrFrom(destination, 0),
-	})
+	}, nil)
 	switch result.Action {
 	case adapter.PreMatchFlow:
 		flowOutbound, isFlowOutbound := result.Outbound.(adapter.FlowOutbound)

--- a/protocol/http/inbound.go
+++ b/protocol/http/inbound.go
@@ -24,7 +24,10 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.HTTPMixedInboundOptions](registry, C.TypeHTTP, NewInbound)
 }
 
-var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+var (
+	_ adapter.TCPInjectableInbound = (*Inbound)(nil)
+	_ adapter.ManagedSSMServer     = (*Inbound)(nil)
+)
 
 type Inbound struct {
 	inbound.Adapter
@@ -32,6 +35,7 @@ type Inbound struct {
 	logger        log.ContextLogger
 	listener      *listener.Listener
 	authenticator *auth.Authenticator
+	tracker       adapter.SSMTracker
 	tlsConfig     tls.ServerConfig
 }
 
@@ -86,6 +90,20 @@ func (h *Inbound) Close() error {
 	)
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	h.authenticator = auth.NewAuthenticator(common.MapIndexed(users, func(index int, user string) auth.User {
+		return auth.User{
+			Username: user,
+			Password: uPSKs[index],
+		}
+	}))
+	return nil
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	if h.tlsConfig != nil {
 		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
@@ -114,6 +132,9 @@ func (h *Inbound) newUserConnection(ctx context.Context, conn net.Conn, metadata
 	}
 	metadata.User = user
 	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackConnection(conn, metadata)
+	}
 	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
 }
 
@@ -128,5 +149,8 @@ func (h *Inbound) streamUserPacketConnection(ctx context.Context, conn N.PacketC
 	}
 	metadata.User = user
 	h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackPacketConnection(conn, metadata)
+	}
 	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
 }

--- a/protocol/hysteria/inbound.go
+++ b/protocol/hysteria/inbound.go
@@ -23,6 +23,8 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.HysteriaInboundOptions](registry, C.TypeHysteria, NewInbound)
 }
 
+var _ adapter.ManagedSSMServer = (*Inbound)(nil)
+
 type Inbound struct {
 	inbound.Adapter
 	router       adapter.Router
@@ -31,6 +33,7 @@ type Inbound struct {
 	tlsConfig    tls.ServerConfig
 	service      *hysteria.Service[int]
 	userNameList []string
+	tracker      adapter.SSMTracker
 }
 
 func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.HysteriaInboundOptions) (adapter.Inbound, error) {
@@ -104,6 +107,26 @@ func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLo
 	return inbound, nil
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ string) int {
+		return index
+	}), uPSKs)
+	h.userNameList = users
+	return nil
+}
+
+func (h *Inbound) userName(userID int) string {
+	userNameList := h.userNameList
+	if userID < 0 || userID >= len(userNameList) {
+		return ""
+	}
+	return userNameList[userID]
+}
+
 func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
 	ctx = log.ContextWithNewID(ctx)
 	var metadata adapter.InboundContext
@@ -117,9 +140,12 @@ func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.S
 	metadata.Destination = destination
 	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
 	userID, _ := auth.UserFromContext[int](ctx)
-	if userName := h.userNameList[userID]; userName != "" {
+	if userName := h.userName(userID); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+		if h.tracker != nil {
+			conn = h.tracker.TrackConnection(conn, metadata)
+		}
 	} else {
 		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
 	}
@@ -139,9 +165,12 @@ func (h *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 	metadata.Destination = destination
 	h.logger.InfoContext(ctx, "inbound packet connection from ", metadata.Source)
 	userID, _ := auth.UserFromContext[int](ctx)
-	if userName := h.userNameList[userID]; userName != "" {
+	if userName := h.userName(userID); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound packet connection to ", metadata.Destination)
+		if h.tracker != nil {
+			conn = h.tracker.TrackPacketConnection(conn, metadata)
+		}
 	} else {
 		h.logger.InfoContext(ctx, "inbound packet connection to ", metadata.Destination)
 	}

--- a/protocol/hysteria2/inbound.go
+++ b/protocol/hysteria2/inbound.go
@@ -32,6 +32,8 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.Hysteria2InboundOptions](registry, C.TypeHysteria2, NewInbound)
 }
 
+var _ adapter.ManagedSSMServer = (*Inbound)(nil)
+
 type Inbound struct {
 	inbound.Adapter
 	router       adapter.Router
@@ -40,6 +42,7 @@ type Inbound struct {
 	tlsConfig    tls.ServerConfig
 	service      *hysteria2.Service[int]
 	userNameList []string
+	tracker      adapter.SSMTracker
 }
 
 func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.Hysteria2InboundOptions) (adapter.Inbound, error) {
@@ -197,6 +200,26 @@ func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLo
 	return inbound, nil
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ string) int {
+		return index
+	}), uPSKs)
+	h.userNameList = users
+	return nil
+}
+
+func (h *Inbound) userName(userID int) string {
+	userNameList := h.userNameList
+	if userID < 0 || userID >= len(userNameList) {
+		return ""
+	}
+	return userNameList[userID]
+}
+
 func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
 	ctx = log.ContextWithNewID(ctx)
 	var metadata adapter.InboundContext
@@ -210,9 +233,12 @@ func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.S
 	metadata.Destination = destination
 	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
 	userID, _ := auth.UserFromContext[int](ctx)
-	if userName := h.userNameList[userID]; userName != "" {
+	if userName := h.userName(userID); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+		if h.tracker != nil {
+			conn = h.tracker.TrackConnection(conn, metadata)
+		}
 	} else {
 		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
 	}
@@ -232,9 +258,12 @@ func (h *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 	metadata.Destination = destination
 	h.logger.InfoContext(ctx, "inbound packet connection from ", metadata.Source)
 	userID, _ := auth.UserFromContext[int](ctx)
-	if userName := h.userNameList[userID]; userName != "" {
+	if userName := h.userName(userID); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound packet connection to ", metadata.Destination)
+		if h.tracker != nil {
+			conn = h.tracker.TrackPacketConnection(conn, metadata)
+		}
 	} else {
 		h.logger.InfoContext(ctx, "inbound packet connection to ", metadata.Destination)
 	}

--- a/protocol/mixed/inbound.go
+++ b/protocol/mixed/inbound.go
@@ -28,7 +28,10 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.HTTPMixedInboundOptions](registry, C.TypeMixed, NewInbound)
 }
 
-var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+var (
+	_ adapter.TCPInjectableInbound = (*Inbound)(nil)
+	_ adapter.ManagedSSMServer     = (*Inbound)(nil)
+)
 
 type Inbound struct {
 	inbound.Adapter
@@ -36,6 +39,7 @@ type Inbound struct {
 	logger        log.ContextLogger
 	listener      *listener.Listener
 	authenticator *auth.Authenticator
+	tracker       adapter.SSMTracker
 	tlsConfig     tls.ServerConfig
 	udpTimeout    time.Duration
 }
@@ -98,6 +102,20 @@ func (h *Inbound) Close() error {
 	)
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	h.authenticator = auth.NewAuthenticator(common.MapIndexed(users, func(index int, user string) auth.User {
+		return auth.User{
+			Username: user,
+			Password: uPSKs[index],
+		}
+	}))
+	return nil
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	err := h.newConnection(ctx, conn, metadata, onClose)
 	N.CloseOnHandshakeFailure(conn, onClose, err)
@@ -142,6 +160,9 @@ func (h *Inbound) newUserConnection(ctx context.Context, conn net.Conn, metadata
 	}
 	metadata.User = user
 	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackConnection(conn, metadata)
+	}
 	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
 }
 
@@ -163,6 +184,9 @@ func (h *Inbound) streamUserPacketConnection(ctx context.Context, conn N.PacketC
 		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection")
 	} else {
 		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	}
+	if h.tracker != nil {
+		conn = h.tracker.TrackPacketConnection(conn, metadata)
 	}
 	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
 }

--- a/protocol/naive/inbound.go
+++ b/protocol/naive/inbound.go
@@ -38,6 +38,8 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.NaiveInboundOptions](registry, C.TypeNaive, NewInbound)
 }
 
+var _ adapter.ManagedSSMServer = (*Inbound)(nil)
+
 type Inbound struct {
 	inbound.Adapter
 	ctx              context.Context
@@ -48,6 +50,7 @@ type Inbound struct {
 	network          []string
 	networkIsDefault bool
 	authenticator    *auth.Authenticator
+	tracker          adapter.SSMTracker
 	tlsConfig        tls.ServerConfig
 	httpServer       *http.Server
 	h3Server         io.Closer
@@ -147,6 +150,20 @@ func (n *Inbound) Close() error {
 	)
 }
 
+func (n *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	n.tracker = tracker
+}
+
+func (n *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	n.authenticator = auth.NewAuthenticator(common.MapIndexed(users, func(index int, user string) auth.User {
+		return auth.User{
+			Username: user,
+			Password: uPSKs[index],
+		}
+	}))
+	return nil
+}
+
 func (n *Inbound) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	ctx := log.ContextWithNewID(request.Context())
 	if request.Method != "CONNECT" {
@@ -160,7 +177,8 @@ func (n *Inbound) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	}
 	userName, password, authOk := sHttp.ParseBasicAuth(request.Header.Get("Proxy-Authorization"))
 	if authOk {
-		authOk = n.authenticator.Verify(userName, password)
+		authenticator := n.authenticator
+		authOk = authenticator != nil && authenticator.Verify(userName, password)
 	}
 	if !authOk {
 		rejectHTTP(writer, http.StatusProxyAuthRequired)
@@ -216,6 +234,9 @@ func (n *Inbound) newConnection(ctx context.Context, waitForClose bool, conn net
 	metadata.Destination = destination
 	metadata.OriginDestination = M.SocksaddrFromNet(conn.LocalAddr()).Unwrap()
 	metadata.User = userName
+	if n.tracker != nil {
+		conn = n.tracker.TrackConnection(conn, metadata)
+	}
 	if !waitForClose {
 		n.router.RouteConnectionEx(ctx, conn, metadata, nil)
 	} else {

--- a/protocol/socks/inbound.go
+++ b/protocol/socks/inbound.go
@@ -13,6 +13,7 @@ import (
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/auth"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/logger"
@@ -24,7 +25,10 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.SocksInboundOptions](registry, C.TypeSOCKS, NewInbound)
 }
 
-var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+var (
+	_ adapter.TCPInjectableInbound = (*Inbound)(nil)
+	_ adapter.ManagedSSMServer     = (*Inbound)(nil)
+)
 
 type Inbound struct {
 	inbound.Adapter
@@ -32,6 +36,7 @@ type Inbound struct {
 	logger        logger.ContextLogger
 	listener      *listener.Listener
 	authenticator *auth.Authenticator
+	tracker       adapter.SSMTracker
 	udpTimeout    time.Duration
 }
 
@@ -70,6 +75,20 @@ func (h *Inbound) Close() error {
 	return h.listener.Close()
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	h.authenticator = auth.NewAuthenticator(common.MapIndexed(users, func(index int, user string) auth.User {
+		return auth.User{
+			Username: user,
+			Password: uPSKs[index],
+		}
+	}))
+	return nil
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	err := socks.HandleConnectionEx(ctx, conn, std_bufio.NewReader(conn), h.authenticator, adapter.NewUpstreamHandler(metadata, h.newUserConnection, h.streamUserPacketConnection), h.listener, h.udpTimeout, metadata.Source, onClose)
 	N.CloseOnHandshakeFailure(conn, onClose, err)
@@ -93,6 +112,9 @@ func (h *Inbound) newUserConnection(ctx context.Context, conn net.Conn, metadata
 	}
 	metadata.User = user
 	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackConnection(conn, metadata)
+	}
 	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
 }
 
@@ -114,6 +136,9 @@ func (h *Inbound) streamUserPacketConnection(ctx context.Context, conn N.PacketC
 		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection")
 	} else {
 		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	}
+	if h.tracker != nil {
+		conn = h.tracker.TrackPacketConnection(conn, metadata)
 	}
 	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
 }

--- a/protocol/tailscale/port.go
+++ b/protocol/tailscale/port.go
@@ -38,7 +38,7 @@ func (t *Endpoint) PortMTU() uint32 {
 	return uint32(tsTUN.DefaultTUNMTU())
 }
 
-func (t *Endpoint) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort) tun.FlowVerdict {
+func (t *Endpoint) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort, firstPacket []byte) tun.FlowVerdict {
 	inet4Address, inet6Address := t.PortAddresses()
 	if destination.Addr() == inet4Address || destination.Addr() == inet6Address {
 		return tun.FlowVerdict{Action: tun.ActionAccept}
@@ -70,7 +70,7 @@ func (t *Endpoint) JudgeFlow(network uint8, source netip.AddrPort, destination n
 			}
 		}
 	}
-	return adapter.JudgeFlow(t.router, t.Tag(), t.Type(), network, source, destination)
+	return adapter.JudgeFlow(t.router, t.Tag(), t.Type(), network, source, destination, firstPacket)
 }
 
 func (t *Endpoint) AttachReturn(returnPath tun.Return) error {

--- a/protocol/trojan/inbound.go
+++ b/protocol/trojan/inbound.go
@@ -27,7 +27,10 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.TrojanInboundOptions](registry, C.TypeTrojan, NewInbound)
 }
 
-var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+var (
+	_ adapter.TCPInjectableInbound = (*Inbound)(nil)
+	_ adapter.ManagedSSMServer     = (*Inbound)(nil)
+)
 
 type Inbound struct {
 	inbound.Adapter
@@ -36,6 +39,7 @@ type Inbound struct {
 	listener                 *listener.Listener
 	service                  *trojan.Service[int]
 	users                    []option.TrojanUser
+	tracker                  adapter.SSMTracker
 	tlsConfig                tls.ServerConfig
 	fallbackAddr             M.Socksaddr
 	fallbackAddrTLSNextProto map[string]M.Socksaddr
@@ -164,6 +168,33 @@ func (h *Inbound) Close() error {
 	)
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	err := h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ string) int {
+		return index
+	}), uPSKs)
+	if err != nil {
+		return err
+	}
+	h.users = common.Map(users, func(user string) option.TrojanUser {
+		return option.TrojanUser{
+			Name: user,
+		}
+	})
+	return nil
+}
+
+func (h *Inbound) userName(userIndex int) string {
+	users := h.users
+	if userIndex < 0 || userIndex >= len(users) {
+		return ""
+	}
+	return users[userIndex].Name
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	if h.tlsConfig != nil && h.transport == nil {
 		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
@@ -189,13 +220,16 @@ func (h *Inbound) newConnection(ctx context.Context, conn net.Conn, metadata ada
 		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
 		return
 	}
-	user := h.users[userIndex].Name
+	user := h.userName(userIndex)
 	if user == "" {
 		user = F.ToString(userIndex)
 	} else {
 		metadata.User = user
 	}
 	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackConnection(conn, metadata)
+	}
 	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
 }
 
@@ -207,13 +241,16 @@ func (h *Inbound) newPacketConnection(ctx context.Context, conn N.PacketConn, me
 		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
 		return
 	}
-	user := h.users[userIndex].Name
+	user := h.userName(userIndex)
 	if user == "" {
 		user = F.ToString(userIndex)
 	} else {
 		metadata.User = user
 	}
 	h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackPacketConnection(conn, metadata)
+	}
 	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
 }
 

--- a/protocol/tuic/inbound.go
+++ b/protocol/tuic/inbound.go
@@ -110,6 +110,38 @@ func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLo
 	return inbound, nil
 }
 
+func (h *Inbound) UpdateUsers(users []option.TUICUser) {
+	var userList []int
+	var userNameList []string
+	var userUUIDList [][16]byte
+	var userPasswordList []string
+	for index, user := range users {
+		if user.UUID == "" {
+			h.logger.Error(E.New("update users: missing uuid for user ", index))
+			return
+		}
+		userUUID, err := uuid.FromString(user.UUID)
+		if err != nil {
+			h.logger.Error(E.Cause(err, "update users: invalid uuid for user ", index))
+			return
+		}
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		userUUIDList = append(userUUIDList, userUUID)
+		userPasswordList = append(userPasswordList, user.Password)
+	}
+	h.userNameList = userNameList
+	h.server.UpdateUsers(userList, userUUIDList, userPasswordList)
+}
+
+func (h *Inbound) userName(userID int) string {
+	userNameList := h.userNameList
+	if userID < 0 || userID >= len(userNameList) {
+		return ""
+	}
+	return userNameList[userID]
+}
+
 func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
 	ctx = log.ContextWithNewID(ctx)
 	var metadata adapter.InboundContext
@@ -123,7 +155,7 @@ func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.S
 	metadata.Destination = destination
 	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
 	userID, _ := auth.UserFromContext[int](ctx)
-	if userName := h.userNameList[userID]; userName != "" {
+	if userName := h.userName(userID); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
 	} else {
@@ -145,7 +177,7 @@ func (h *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 	metadata.Destination = destination
 	h.logger.InfoContext(ctx, "inbound packet connection from ", metadata.Source)
 	userID, _ := auth.UserFromContext[int](ctx)
-	if userName := h.userNameList[userID]; userName != "" {
+	if userName := h.userName(userID); userName != "" {
 		metadata.User = userName
 		h.logger.InfoContext(ctx, "[", userName, "] inbound packet connection to ", metadata.Destination)
 	} else {

--- a/protocol/tun/inbound.go
+++ b/protocol/tun/inbound.go
@@ -478,8 +478,13 @@ func (t *Inbound) Close() error {
 	)
 }
 
-func (t *Inbound) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort) tun.FlowVerdict {
-	return adapter.JudgeFlow(t.router, t.tag, C.TypeTun, network, source, destination)
+func (t *Inbound) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort, firstPacket []byte) tun.FlowVerdict {
+	for _, dnsHijackAddress := range t.dnsHijackAddress {
+		if destination.Addr() == dnsHijackAddress {
+			return tun.FlowVerdict{Action: tun.ActionAccept}
+		}
+	}
+	return adapter.JudgeFlow(t.router, t.tag, C.TypeTun, network, source, destination, firstPacket)
 }
 
 func (t *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
@@ -526,8 +531,8 @@ func (t *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 
 type autoRedirectHandler Inbound
 
-func (t *autoRedirectHandler) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort) tun.FlowVerdict {
-	return (*Inbound)(t).JudgeFlow(network, source, destination)
+func (t *autoRedirectHandler) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort, firstPacket []byte) tun.FlowVerdict {
+	return (*Inbound)(t).JudgeFlow(network, source, destination, firstPacket)
 }
 
 func (t *autoRedirectHandler) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {

--- a/protocol/vless/inbound.go
+++ b/protocol/vless/inbound.go
@@ -147,6 +147,25 @@ func (h *Inbound) Close() error {
 	)
 }
 
+func (h *Inbound) UpdateUsers(users []option.VLESSUser) {
+	h.users = users
+	h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.VLESSUser) int {
+		return index
+	}), common.Map(users, func(it option.VLESSUser) string {
+		return it.UUID
+	}), common.Map(users, func(it option.VLESSUser) string {
+		return it.Flow
+	}))
+}
+
+func (h *Inbound) userName(userIndex int) string {
+	users := h.users
+	if userIndex < 0 || userIndex >= len(users) {
+		return ""
+	}
+	return users[userIndex].Name
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	if h.tlsConfig != nil && h.transport == nil {
 		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
@@ -172,7 +191,7 @@ func (h *Inbound) newConnectionEx(ctx context.Context, conn net.Conn, metadata a
 		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
 		return
 	}
-	user := h.users[userIndex].Name
+	user := h.userName(userIndex)
 	if user == "" {
 		user = F.ToString(userIndex)
 	} else {
@@ -190,7 +209,7 @@ func (h *Inbound) newPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
 		return
 	}
-	user := h.users[userIndex].Name
+	user := h.userName(userIndex)
 	if user == "" {
 		user = F.ToString(userIndex)
 	} else {

--- a/protocol/vmess/inbound.go
+++ b/protocol/vmess/inbound.go
@@ -32,7 +32,10 @@ func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.VMessInboundOptions](registry, C.TypeVMess, NewInbound)
 }
 
-var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+var (
+	_ adapter.TCPInjectableInbound = (*Inbound)(nil)
+	_ adapter.ManagedSSMServer     = (*Inbound)(nil)
+)
 
 type Inbound struct {
 	inbound.Adapter
@@ -42,6 +45,7 @@ type Inbound struct {
 	listener  *listener.Listener
 	service   *vmess.Service[int]
 	users     []option.VMessUser
+	tracker   adapter.SSMTracker
 	tlsConfig tls.ServerConfig
 	transport adapter.V2RayServerTransport
 }
@@ -153,6 +157,33 @@ func (h *Inbound) Close() error {
 	)
 }
 
+func (h *Inbound) SetTracker(tracker adapter.SSMTracker) {
+	h.tracker = tracker
+}
+
+func (h *Inbound) UpdateUsers(users []string, uPSKs []string) error {
+	err := h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ string) int {
+		return index
+	}), uPSKs, make([]int, len(users)))
+	if err != nil {
+		return err
+	}
+	h.users = common.Map(users, func(user string) option.VMessUser {
+		return option.VMessUser{
+			Name: user,
+		}
+	})
+	return nil
+}
+
+func (h *Inbound) userName(userIndex int) string {
+	users := h.users
+	if userIndex < 0 || userIndex >= len(users) {
+		return ""
+	}
+	return users[userIndex].Name
+}
+
 func (h *Inbound) NewConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	if h.tlsConfig != nil && h.transport == nil {
 		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
@@ -178,13 +209,16 @@ func (h *Inbound) newConnectionEx(ctx context.Context, conn net.Conn, metadata a
 		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
 		return
 	}
-	user := h.users[userIndex].Name
+	user := h.userName(userIndex)
 	if user == "" {
 		user = F.ToString(userIndex)
 	} else {
 		metadata.User = user
 	}
 	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	if h.tracker != nil {
+		conn = h.tracker.TrackConnection(conn, metadata)
+	}
 	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
 }
 
@@ -196,7 +230,7 @@ func (h *Inbound) newPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
 		return
 	}
-	user := h.users[userIndex].Name
+	user := h.userName(userIndex)
 	if user == "" {
 		user = F.ToString(userIndex)
 	} else {
@@ -208,6 +242,9 @@ func (h *Inbound) newPacketConnectionEx(ctx context.Context, conn N.PacketConn, 
 		h.logger.InfoContext(ctx, "[", user, "] inbound packet addr connection")
 	} else {
 		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	}
+	if h.tracker != nil {
+		conn = h.tracker.TrackPacketConnection(conn, metadata)
 	}
 	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
 }

--- a/protocol/wireguard/endpoint.go
+++ b/protocol/wireguard/endpoint.go
@@ -161,13 +161,13 @@ func (w *Endpoint) DetachReturn(returnPath tun.Return) error {
 	return w.endpoint.DetachReturn(returnPath)
 }
 
-func (w *Endpoint) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort) tun.FlowVerdict {
+func (w *Endpoint) JudgeFlow(network uint8, source netip.AddrPort, destination netip.AddrPort, firstPacket []byte) tun.FlowVerdict {
 	for _, localPrefix := range w.localAddresses {
 		if localPrefix.Contains(destination.Addr()) {
 			return tun.FlowVerdict{Action: tun.ActionAccept}
 		}
 	}
-	return adapter.JudgeFlow(w.router, w.Tag(), w.Type(), network, source, destination)
+	return adapter.JudgeFlow(w.router, w.Tag(), w.Type(), network, source, destination, firstPacket)
 }
 
 func (w *Endpoint) WritePackets(packets [][]byte) error {

--- a/route/flow_tracker.go
+++ b/route/flow_tracker.go
@@ -1,0 +1,101 @@
+package route
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-tun"
+	"github.com/sagernet/sing/common/byteformats"
+	N "github.com/sagernet/sing/common/network"
+)
+
+var (
+	_ tun.FlowTracker = (*flowLogger)(nil)
+	_ tun.FlowTracker = (multiFlowTracker)(nil)
+)
+
+type flowLogger struct {
+	ctx         context.Context
+	logger      log.ContextLogger
+	network     string
+	source      string
+	destination string
+	outbound    adapter.Outbound
+	createdAt   time.Time
+	upload      atomic.Int64
+	download    atomic.Int64
+}
+
+func newFlowLogger(ctx context.Context, logger log.ContextLogger, metadata adapter.InboundContext, outbound adapter.Outbound) *flowLogger {
+	var source, destination string
+	if metadata.Network == N.NetworkICMP {
+		source = metadata.Source.AddrString()
+		destination = metadata.Destination.AddrString()
+	} else {
+		source = metadata.Source.String()
+		destination = metadata.Destination.String()
+	}
+	return &flowLogger{
+		ctx:         ctx,
+		logger:      logger,
+		network:     metadata.Network,
+		source:      source,
+		destination: destination,
+		outbound:    outbound,
+	}
+}
+
+func (l *flowLogger) AttachFlow(handle tun.FlowHandle) {
+	l.createdAt = time.Now()
+}
+
+func (l *flowLogger) CountForward(n int) {
+	l.upload.Add(int64(n))
+}
+
+func (l *flowLogger) CountReverse(n int) {
+	l.download.Add(int64(n))
+}
+
+func (l *flowLogger) FlowEstablished() {
+}
+
+func (l *flowLogger) CloseFlow(reason tun.FlowCloseReason) {
+	l.logger.DebugContext(l.ctx, "flow closed: ", reason,
+		", upload ", byteformats.FormatBytes(uint64(l.upload.Load())), ", download ", byteformats.FormatBytes(uint64(l.download.Load())))
+}
+
+type multiFlowTracker []tun.FlowTracker
+
+func (t multiFlowTracker) AttachFlow(handle tun.FlowHandle) {
+	for _, tracker := range t {
+		tracker.AttachFlow(handle)
+	}
+}
+
+func (t multiFlowTracker) CountForward(n int) {
+	for _, tracker := range t {
+		tracker.CountForward(n)
+	}
+}
+
+func (t multiFlowTracker) CountReverse(n int) {
+	for _, tracker := range t {
+		tracker.CountReverse(n)
+	}
+}
+
+func (t multiFlowTracker) FlowEstablished() {
+	for _, tracker := range t {
+		tracker.FlowEstablished()
+	}
+}
+
+func (t multiFlowTracker) CloseFlow(reason tun.FlowCloseReason) {
+	for _, tracker := range t {
+		tracker.CloseFlow(reason)
+	}
+}

--- a/route/route.go
+++ b/route/route.go
@@ -12,8 +12,10 @@ import (
 	"github.com/sagernet/sing-box/common/dialer"
 	"github.com/sagernet/sing-box/common/sniff"
 	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
 	R "github.com/sagernet/sing-box/route/rule"
 	"github.com/sagernet/sing-mux"
+	"github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing-vmess"
 	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
@@ -27,6 +29,16 @@ import (
 
 	"golang.org/x/exp/slices"
 )
+
+var defaultPacketSniffers = []sniff.PacketSniffer{
+	sniff.DomainNameQuery,
+	sniff.QUICClientHello,
+	sniff.STUNMessage,
+	sniff.UTP,
+	sniff.UDPTracker,
+	sniff.DTLSRecord,
+	sniff.NTP,
+}
 
 // Deprecated: use RouteConnectionEx instead.
 func (r *Router) RouteConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext) error {
@@ -294,7 +306,8 @@ func (r *Router) routePacketConnection(ctx context.Context, conn N.PacketConn, m
 	return nil
 }
 
-func (r *Router) PreMatch(metadata adapter.InboundContext) adapter.PreMatchResult {
+func (r *Router) PreMatch(metadata adapter.InboundContext, firstPacket []byte) adapter.PreMatchResult {
+	ctx := log.ContextWithNewID(r.ctx)
 	continueResult := adapter.PreMatchResult{Action: adapter.PreMatchContinue}
 	packetDestination := metadata.Destination
 	if metadata.Destination.Addr.IsValid() && r.dnsTransport.FakeIP() != nil && r.dnsTransport.FakeIP().Store().Contains(metadata.Destination.Addr) {
@@ -319,46 +332,89 @@ func (r *Router) PreMatch(metadata adapter.InboundContext) adapter.PreMatchResul
 		if !currentRule.Match(&metadata) {
 			continue
 		}
+		ruleDescription := currentRule.String()
+		if ruleDescription != "" {
+			r.logger.DebugContext(ctx, "pre-match[", currentRuleIndex, "] ", currentRule, " => ", currentRule.Action())
+		} else {
+			r.logger.DebugContext(ctx, "pre-match[", currentRuleIndex, "] => ", currentRule.Action())
+		}
 		switch action := currentRule.Action().(type) {
 		case *R.RuleActionSniff:
 			if metadata.Network == N.NetworkICMP {
 				continue
 			}
-			return continueResult
+			if metadata.Network != N.NetworkUDP || len(firstPacket) == 0 {
+				return continueResult
+			}
+			if sniff.Skip(&metadata) || metadata.Protocol != "" {
+				continue
+			}
+			if len(action.PacketSniffers) == 0 && len(action.StreamSniffers) > 0 {
+				continue
+			}
+			if slices.Equal(metadata.SnifferNames, action.SnifferNames) && metadata.SniffError != nil {
+				continue
+			}
+			packetSniffers := action.PacketSniffers
+			if len(packetSniffers) == 0 {
+				packetSniffers = defaultPacketSniffers
+			}
+			sniffErr := sniff.PeekPacket(ctx, &metadata, firstPacket, packetSniffers...)
+			metadata.SnifferNames = action.SnifferNames
+			metadata.SniffError = sniffErr
+			if sniffErr != nil {
+				if errors.Is(sniffErr, sniff.ErrNeedMoreData) {
+					return continueResult
+				}
+				continue
+			}
+			//goland:noinspection GoDeprecation
+			if action.OverrideDestination && M.IsDomainName(metadata.Domain) {
+				metadata.Destination = M.Socksaddr{
+					Fqdn: metadata.Domain,
+					Port: metadata.Destination.Port,
+				}
+			}
+			if metadata.Domain != "" && metadata.Client != "" {
+				r.logger.DebugContext(ctx, "sniffed packet protocol: ", metadata.Protocol, ", domain: ", metadata.Domain, ", client: ", metadata.Client)
+			} else if metadata.Domain != "" {
+				r.logger.DebugContext(ctx, "sniffed packet protocol: ", metadata.Protocol, ", domain: ", metadata.Domain)
+			} else if metadata.Client != "" {
+				r.logger.DebugContext(ctx, "sniffed packet protocol: ", metadata.Protocol, ", client: ", metadata.Client)
+			} else {
+				r.logger.DebugContext(ctx, "sniffed packet protocol: ", metadata.Protocol)
+			}
 		case *R.RuleActionRouteOptions:
 			applyRouteOptionsOverride(&metadata, action)
 		case *R.RuleActionRoute:
 			applyRouteOptionsOverride(&metadata, &action.RuleActionRouteOptions)
-			r.logger.Debug("pre-match[", currentRuleIndex, "] ", currentRule, " => ", action)
-			return r.preMatchFlow(&metadata, packetDestination, action.Outbound)
+			return r.preMatchFlow(ctx, &metadata, packetDestination, currentRule, action.Outbound)
 		case *R.RuleActionBypass:
 			applyRouteOptionsOverride(&metadata, &action.RuleActionRouteOptions)
-			r.logger.Debug("pre-match[", currentRuleIndex, "] ", currentRule, " => ", action)
 			if action.Outbound == "" {
 				if metadata.Destination.IsDomain() || metadata.Destination != packetDestination {
 					return continueResult
 				}
 				return adapter.PreMatchResult{Action: adapter.PreMatchBypass}
 			}
-			return r.preMatchFlow(&metadata, packetDestination, action.Outbound)
+			return r.preMatchFlow(ctx, &metadata, packetDestination, currentRule, action.Outbound)
 		case *R.RuleActionReject:
-			r.logger.Debug("pre-match[", currentRuleIndex, "] ", currentRule, " => ", action)
 			rejectErr := action.Error(r.ctx)
 			if errors.Is(rejectErr, R.ErrDrop) {
 				return adapter.PreMatchResult{Action: adapter.PreMatchDrop}
 			}
 			return adapter.PreMatchResult{Action: adapter.PreMatchReject}
 		case *R.RuleActionResolve:
-			resolveErr := r.actionResolve(adapter.WithContext(r.ctx, &metadata), &metadata, action)
+			resolveErr := r.actionResolve(adapter.WithContext(ctx, &metadata), &metadata, action)
 			if resolveErr != nil {
-				r.logger.Debug("pre-match[", currentRuleIndex, "] ", currentRule, " => ", action, ": ", resolveErr)
+				r.logger.DebugContext(ctx, "pre-match[", currentRuleIndex, "] ", currentRule, " => ", action, ": ", resolveErr)
 				return adapter.PreMatchResult{Action: adapter.PreMatchReject}
 			}
 		default:
 			return continueResult
 		}
 	}
-	return r.preMatchFlow(&metadata, packetDestination, "")
+	return r.preMatchFlow(ctx, &metadata, packetDestination, nil, "")
 }
 
 func applyRouteOptionsOverride(metadata *adapter.InboundContext, routeOptions *R.RuleActionRouteOptions) {
@@ -378,7 +434,7 @@ func applyRouteOptionsOverride(metadata *adapter.InboundContext, routeOptions *R
 	}
 }
 
-func (r *Router) preMatchFlow(metadata *adapter.InboundContext, packetDestination M.Socksaddr, outboundTag string) adapter.PreMatchResult {
+func (r *Router) preMatchFlow(ctx context.Context, metadata *adapter.InboundContext, packetDestination M.Socksaddr, matchedRule adapter.Rule, outboundTag string) adapter.PreMatchResult {
 	continueResult := adapter.PreMatchResult{Action: adapter.PreMatchContinue}
 	var outbound adapter.Outbound
 	if outboundTag == "" {
@@ -409,7 +465,7 @@ func (r *Router) preMatchFlow(metadata *adapter.InboundContext, packetDestinatio
 		if outbound.Type() == C.TypeDirect {
 			directDialer, isDirectDialer := outbound.(dialer.DirectDialer)
 			if isDirectDialer && directDialer.IsEmpty() && !metadata.Destination.IsDomain() && metadata.Destination == packetDestination {
-				r.logger.Debug("pre-match bypass ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to ", metadata.Destination.AddrString())
+				r.logger.DebugContext(ctx, "pre-match bypass ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to ", metadata.Destination.AddrString())
 				return adapter.PreMatchResult{Action: adapter.PreMatchBypass, Outbound: outbound}
 			}
 		}
@@ -429,9 +485,9 @@ func (r *Router) preMatchFlow(metadata *adapter.InboundContext, packetDestinatio
 		}
 		if !newDestination.IsValid() {
 			if len(metadata.DestinationAddresses) == 0 {
-				r.logger.Warn("pre-match: reject ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to fake destination ", metadata.Destination.Fqdn, ": a resolve action is required before routing to outbound/", outbound.Type(), "[", outbound.Tag(), "]")
+				r.logger.WarnContext(ctx, "pre-match: reject ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to fake destination ", metadata.Destination.Fqdn, ": a resolve action is required before routing to outbound/", outbound.Type(), "[", outbound.Tag(), "]")
 			} else {
-				r.logger.Debug("pre-match: reject ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to fake destination ", metadata.Destination.Fqdn, ": no resolved address for this address family")
+				r.logger.DebugContext(ctx, "pre-match: reject ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to fake destination ", metadata.Destination.Fqdn, ": no resolved address for this address family")
 			}
 			return adapter.PreMatchResult{Action: adapter.PreMatchReject}
 		}
@@ -439,7 +495,22 @@ func (r *Router) preMatchFlow(metadata *adapter.InboundContext, packetDestinatio
 	} else if metadata.Destination != packetDestination {
 		result.Destination = metadata.Destination.AddrPort()
 	}
-	r.logger.Debug("pre-match forward ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to ", metadata.Destination.AddrString(), " via outbound/", outbound.Type(), "[", outbound.Tag(), "]")
+	r.logger.InfoContext(ctx, "pre-match: forward ", metadata.Network, " connection from ", metadata.Source.AddrString(), " to ", metadata.Destination.AddrString(), " via outbound/", outbound.Type(), "[", outbound.Tag(), "]")
+	metadataCopy := *metadata
+	result.NewTracker = func() tun.FlowTracker {
+		flowTrackers := make([]tun.FlowTracker, 0, len(r.trackers)+1)
+		flowTrackers = append(flowTrackers, newFlowLogger(ctx, r.logger, metadataCopy, outbound))
+		for _, tracker := range r.trackers {
+			flowTracker := tracker.RoutedFlow(ctx, metadataCopy, matchedRule, outbound)
+			if flowTracker != nil {
+				flowTrackers = append(flowTrackers, flowTracker)
+			}
+		}
+		if len(flowTrackers) == 1 {
+			return flowTrackers[0]
+		}
+		return multiFlowTracker(flowTrackers)
+	}
 	return result
 }
 
@@ -678,15 +749,7 @@ func (r *Router) actionSniff(
 		if len(action.PacketSniffers) > 0 {
 			packetSniffers = action.PacketSniffers
 		} else {
-			packetSniffers = []sniff.PacketSniffer{
-				sniff.DomainNameQuery,
-				sniff.QUICClientHello,
-				sniff.STUNMessage,
-				sniff.UTP,
-				sniff.UDPTracker,
-				sniff.DTLSRecord,
-				sniff.NTP,
-			}
+			packetSniffers = defaultPacketSniffers
 		}
 		var err error
 		for _, packetBuffer := range inputPacketBuffers {


### PR DESCRIPTION
## Motivation

The SSM API service currently manages users only for multi-user Shadowsocks
inbounds. Every other multi-user inbound requires a full instance restart to
apply a user change, which drops all active connections — even though the
underlying services (transport/trojan, sing-vmess, sing-quic, sing-anytls)
already support live user replacement, and the SSM API service itself is
written against a generic `adapter.ManagedSSMServer` interface rather than
anything Shadowsocks-specific.

This PR implements `adapter.ManagedSSMServer` on the remaining inbounds whose
user model fits the SSM credential model (one user name + one key), so they
can be listed in the ssm-api `servers` map and managed at runtime:

HTTP, Mixed, SOCKS, Naive, Trojan, VMess, AnyTLS, Hysteria, and Hysteria2.

## What's changed

- Each inbound gains `UpdateUsers`/`SetTracker`, mirroring the existing
  Shadowsocks `MultiInbound` implementation, and wraps authenticated
  connections with the SSM tracker for per-user traffic accounting.
- Trojan/VMess/AnyTLS/Hysteria/Hysteria2 delegate to the existing
  `Service.UpdateUsers` of their protocol libraries; HTTP/Mixed/SOCKS/Naive
  rebuild their `auth.Authenticator`.
- User name lookups by index are now bounds-checked, since the user list can
  shrink while long-lived (QUIC) connections still resolve names with an old
  index.
- No new configuration surface: unlike Shadowsocks, these inbounds have no
  single-user/multi-user service split, so the `managed` flag is not needed —
  referencing the inbound from ssm-api `servers` is sufficient.
- Documentation updated (en/zh).

## Scope notes

- VMess: the SSM user key maps to the UUID; managed users use `alterId` 0.
- VLESS and TUIC are intentionally excluded: their users cannot be expressed
  as a single credential (`flow`, and `uuid` + `password` respectively).

## Verification

Manually exercised against a running instance: users added/updated/deleted
via the REST endpoints take effect immediately on Trojan and Mixed inbounds
(new credentials authenticate, removed/replaced credentials are rejected),
and per-user traffic counters appear in `/server/v1/stats`.
