### PR TITLE
Make process name and path matching case-insensitive on Windows

### DIFF
--- a/docs/configuration/outbound/anytls.md
+++ b/docs/configuration/outbound/anytls.md
@@ -17,6 +17,7 @@ icon: material/new-box
   "idle_session_check_interval": "30s",
   "idle_session_timeout": "30s",
   "min_idle_session": 5,
+  "disable_reuse": false,
   "tls": {},
 
   ... // Dial Fields
@@ -54,6 +55,10 @@ In the check, close sessions that have been idle for longer than this. Default: 
 #### min_idle_session
 
 In the check, at least the first `n` idle sessions are kept open. Default value: `n`=0
+
+#### disable_reuse
+
+Disable TLS connection reuse. Default: false.
 
 #### tls
 

--- a/docs/configuration/outbound/anytls.zh.md
+++ b/docs/configuration/outbound/anytls.zh.md
@@ -17,6 +17,7 @@ icon: material/new-box
   "idle_session_check_interval": "30s",
   "idle_session_timeout": "30s",
   "min_idle_session": 5,
+  "disable_reuse": false,
   "tls": {},
 
   ... // 拨号字段
@@ -54,6 +55,10 @@ AnyTLS 密码。
 #### min_idle_session
 
 在检查中，至少前 `n` 个空闲会话保持打开状态。默认值：`n`=0
+
+#### disable_reuse
+
+禁用 TLS 连接复用。默认值：false。
 
 #### tls
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.7
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.26.0
-	github.com/anytls/sing-anytls v0.0.11
+	github.com/anytls/sing-anytls v0.0.13
 	github.com/caddyserver/certmagic v0.25.2
 	github.com/coder/websocket v1.8.14
 	github.com/cretz/bine v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
-github.com/anytls/sing-anytls v0.0.11 h1:w8e9Uj1oP3m4zxkyZDewPk0EcQbvVxb7Nn+rapEx4fc=
-github.com/anytls/sing-anytls v0.0.11/go.mod h1:7rjN6IukwysmdusYsrV51Fgu1uW6vsrdd6ctjnEAln8=
+github.com/anytls/sing-anytls v0.0.13 h1:FL+krjOmwpYYLpl5rrV/BrzDMfxbi05YgIQh+NAA37c=
+github.com/anytls/sing-anytls v0.0.13/go.mod h1:7rjN6IukwysmdusYsrV51Fgu1uW6vsrdd6ctjnEAln8=
 github.com/caddyserver/certmagic v0.25.2 h1:D7xcS7ggX/WEY54x0czj7ioTkmDWKIgxtIi2OcQclUc=
 github.com/caddyserver/certmagic v0.25.2/go.mod h1:llW/CvsNmza8S6hmsuggsZeiX+uS27dkqY27wDIuBWg=
 github.com/caddyserver/zerossl v0.1.5 h1:dkvOjBAEEtY6LIGAHei7sw2UgqSD6TrWweXpV7lvEvE=

--- a/option/anytls.go
+++ b/option/anytls.go
@@ -22,4 +22,5 @@ type AnyTLSOutboundOptions struct {
 	IdleSessionCheckInterval badoption.Duration `json:"idle_session_check_interval,omitempty"`
 	IdleSessionTimeout       badoption.Duration `json:"idle_session_timeout,omitempty"`
 	MinIdleSession           int                `json:"min_idle_session,omitempty"`
+	DisableReuse             bool               `json:"disable_reuse,omitempty"`
 }

--- a/protocol/anytls/outbound.go
+++ b/protocol/anytls/outbound.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/outbound"
@@ -19,10 +20,15 @@ import (
 	"github.com/sagernet/sing/common/uot"
 
 	anytls "github.com/anytls/sing-anytls"
+	"github.com/anytls/sing-anytls/util"
 )
 
 func RegisterOutbound(registry *outbound.Registry) {
 	outbound.Register[option.AnyTLSOutboundOptions](registry, C.TypeAnyTLS, NewOutbound)
+
+	if !strings.Contains(util.Version, "sing-box") {
+		util.Version = util.Version + " sing-box/" + C.Version
+	}
 }
 
 type Outbound struct {
@@ -74,6 +80,7 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 		IdleSessionCheckInterval: options.IdleSessionCheckInterval.Build(),
 		IdleSessionTimeout:       options.IdleSessionTimeout.Build(),
 		MinIdleSession:           options.MinIdleSession,
+		DisableReuse:             options.DisableReuse,
 		DialOut:                  outbound.dialOut,
 		Logger:                   logger,
 	})

--- a/route/rule/rule_item_process_name.go
+++ b/route/rule/rule_item_process_name.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
 )
 
 var _ RuleItem = (*ProcessItem)(nil)
@@ -20,6 +21,9 @@ func NewProcessItem(processNameList []string) *ProcessItem {
 		processMap: make(map[string]bool),
 	}
 	for _, processName := range processNameList {
+		if C.IsWindows {
+			processName = strings.ToLower(processName)
+		}
 		rule.processMap[processName] = true
 	}
 	return rule
@@ -29,7 +33,11 @@ func (r *ProcessItem) Match(metadata *adapter.InboundContext) bool {
 	if metadata.ProcessInfo == nil || metadata.ProcessInfo.ProcessPath == "" {
 		return false
 	}
-	return r.processMap[filepath.Base(metadata.ProcessInfo.ProcessPath)]
+	path := filepath.Base(metadata.ProcessInfo.ProcessPath)
+	if C.IsWindows {
+		path = strings.ToLower(path)
+	}
+	return r.processMap[path]
 }
 
 func (r *ProcessItem) String() string {

--- a/route/rule/rule_item_process_path.go
+++ b/route/rule/rule_item_process_path.go
@@ -20,6 +20,9 @@ func NewProcessPathItem(processNameList []string) *ProcessPathItem {
 		processMap: make(map[string]bool),
 	}
 	for _, processName := range processNameList {
+		if C.IsWindows {
+			processName = strings.ToLower(processName)
+		}
 		rule.processMap[processName] = true
 	}
 	return rule
@@ -29,7 +32,11 @@ func (r *ProcessPathItem) Match(metadata *adapter.InboundContext) bool {
 	if metadata.ProcessInfo == nil {
 		return false
 	}
-	if metadata.ProcessInfo.ProcessPath != "" && r.processMap[metadata.ProcessInfo.ProcessPath] {
+	path := metadata.ProcessInfo.ProcessPath
+	if C.IsWindows {
+		path = strings.ToLower(path)
+	}
+	if path != "" && r.processMap[path] {
 		return true
 	}
 	if C.IsAndroid {


### PR DESCRIPTION
Windows file paths are case-insensitive, `C:\Program Files\myPath` and `c:\program files\mypath` point to the same directory. This normalizes `processPath` and `processName` to lowercase on Windows before storing in/loading from `rule.processMap`. `metadata.ProcessInfo.ProcessPath` and `metadata.ProcessInfo.ProcessName` are not modified. 