### PR TITLE
Fix route_address_set duplicated IP sets causing route creation failure

### DIFF
--- a/protocol/tun/inbound.go
+++ b/protocol/tun/inbound.go
@@ -301,7 +301,6 @@ func (t *Inbound) Start(stage adapter.StartStage) error {
 			t.tunOptions.Name = tun.CalculateInterfaceName("")
 		}
 		if t.platformInterface == nil {
-			t.routeAddressSet = common.FlatMap(t.routeRuleSet, adapter.RuleSet.ExtractIPSet)
 			for _, routeRuleSet := range t.routeRuleSet {
 				ipSets := routeRuleSet.ExtractIPSet()
 				if len(ipSets) == 0 {
@@ -313,7 +312,6 @@ func (t *Inbound) Start(stage adapter.StartStage) error {
 					t.routeRuleSetCallback = append(t.routeRuleSetCallback, routeRuleSet.RegisterCallback(t.updateRouteAddressSet))
 				}
 			}
-			t.routeExcludeAddressSet = common.FlatMap(t.routeExcludeRuleSet, adapter.RuleSet.ExtractIPSet)
 			for _, routeExcludeRuleSet := range t.routeExcludeRuleSet {
 				ipSets := routeExcludeRuleSet.ExtractIPSet()
 				if len(ipSets) == 0 {


### PR DESCRIPTION
## Fixes

TUN startup with `route_address_set` or `route_exclude_address_set` could add every rule-set prefix twice and fail on Windows with “The object already exists”; each prefix is now added once while rule-set updates continue to work. This restores the Windows behavior fixed for issue #3725 and released in 1.12.20 through 1.12.25 after the fix did not reach the newer release line. Existing configurations require no changes.

## Verification

Confirmed that 1.13.14, 1.14.0-beta.2, and unmodified testing fail the same administrator-only Windows reproduction, while 1.12.21 and the equivalent literal `route_address` configuration start successfully. Built testing before and after the change with the Windows release tags; the patched binary started the same `route_address_set` reproduction in three clean cycles, installed one route each time, and left no adapter or route behind.