### PR TITLE
Fix AnyTLS URLTest results

### DIFF
--- a/protocol/anytls/outbound.go
+++ b/protocol/anytls/outbound.go
@@ -25,6 +25,8 @@ func RegisterOutbound(registry *outbound.Registry) {
 	outbound.Register[option.AnyTLSOutboundOptions](registry, C.TypeAnyTLS, NewOutbound)
 }
 
+var _ adapter.OutboundWithMultiplex = (*Outbound)(nil)
+
 type Outbound struct {
 	outbound.Adapter
 	dialer    tls.Dialer
@@ -101,6 +103,10 @@ func (d anytlsDialer) ListenPacket(ctx context.Context, destination M.Socksaddr)
 
 func (h *Outbound) dialOut(ctx context.Context) (net.Conn, error) {
 	return h.dialer.DialTLSContext(ctx, h.server)
+}
+
+func (h *Outbound) MultiplexEnabled() bool {
+	return true
 }
 
 func (h *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {


### PR DESCRIPTION
## Summary

- AnyTLS always uses multiplexed sessions, but its outbound does not implement adapter.OutboundWithMultiplex.
- Expose multiplex support so URLTest performs the same warm-up used by other multiplex outbounds.
- Keep the change limited to the AnyTLS outbound.

## Testing

- go test ./protocol/anytls ./common/urltest