### PR TITLE
Fix DNS router reset when network changed

### DIFF
--- a/experimental/clashapi/connections.go
+++ b/experimental/clashapi/connections.go
@@ -18,10 +18,10 @@ import (
 	"github.com/gofrs/uuid/v5"
 )
 
-func connectionRouter(ctx context.Context, router adapter.Router, trafficManager *trafficontrol.Manager) http.Handler {
+func connectionRouter(ctx context.Context, network adapter.NetworkManager, trafficManager *trafficontrol.Manager) http.Handler {
 	r := chi.NewRouter()
 	r.Get("/", getConnections(ctx, trafficManager))
-	r.Delete("/", closeAllConnections(router, trafficManager))
+	r.Delete("/", closeAllConnections(network, trafficManager))
 	r.Delete("/{id}", closeConnection(trafficManager))
 	return r
 }
@@ -96,13 +96,13 @@ func closeConnection(trafficManager *trafficontrol.Manager) func(w http.Response
 	}
 }
 
-func closeAllConnections(router adapter.Router, trafficManager *trafficontrol.Manager) func(w http.ResponseWriter, r *http.Request) {
+func closeAllConnections(network adapter.NetworkManager, trafficManager *trafficontrol.Manager) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		snapshot := trafficManager.Snapshot()
 		for _, c := range snapshot.Connections {
 			c.Close()
 		}
-		router.ResetNetwork()
+		network.ResetNetwork()
 		render.NoContent(w, r)
 	}
 }

--- a/experimental/clashapi/server.go
+++ b/experimental/clashapi/server.go
@@ -42,6 +42,7 @@ var _ adapter.ClashServer = (*Server)(nil)
 
 type Server struct {
 	ctx            context.Context
+	network        adapter.NetworkManager
 	router         adapter.Router
 	dnsRouter      adapter.DNSRouter
 	outbound       adapter.OutboundManager
@@ -67,6 +68,7 @@ func NewServer(ctx context.Context, logFactory log.ObservableFactory, options op
 	chiRouter := chi.NewRouter()
 	s := &Server{
 		ctx:       ctx,
+		network:   service.FromContext[adapter.NetworkManager](ctx),
 		router:    service.FromContext[adapter.Router](ctx),
 		dnsRouter: service.FromContext[adapter.DNSRouter](ctx),
 		outbound:  service.FromContext[adapter.OutboundManager](ctx),
@@ -121,7 +123,7 @@ func NewServer(ctx context.Context, logFactory log.ObservableFactory, options op
 		r.Mount("/configs", configRouter(s, logFactory))
 		r.Mount("/proxies", proxyRouter(s, s.router))
 		r.Mount("/rules", ruleRouter(s.router))
-		r.Mount("/connections", connectionRouter(s.ctx, s.router, trafficManager))
+		r.Mount("/connections", connectionRouter(s.ctx, s.network, trafficManager))
 		r.Mount("/providers/proxies", proxyProviderRouter())
 		r.Mount("/providers/rules", ruleProviderRouter())
 		r.Mount("/script", scriptRouter())

--- a/experimental/libbox/command_server.go
+++ b/experimental/libbox/command_server.go
@@ -235,7 +235,7 @@ func (s *CommandServer) ResetNetwork() {
 	if instance == nil || instance.Box() == nil {
 		return
 	}
-	instance.Box().Router().ResetNetwork()
+	instance.Box().Network().ResetNetwork()
 }
 
 func (s *CommandServer) UpdateWIFIState() {

--- a/route/network.go
+++ b/route/network.go
@@ -34,10 +34,11 @@ import (
 var _ adapter.NetworkManager = (*NetworkManager)(nil)
 
 type NetworkManager struct {
-	logger            logger.ContextLogger
-	interfaceFinder   *control.DefaultInterfaceFinder
-	networkInterfaces common.TypedValue[[]adapter.NetworkInterface]
-
+	ctx                    context.Context
+	logger                 logger.ContextLogger
+	router                 adapter.Router
+	interfaceFinder        *control.DefaultInterfaceFinder
+	networkInterfaces      common.TypedValue[[]adapter.NetworkInterface]
 	autoDetectInterface    bool
 	defaultOptions         adapter.NetworkOptions
 	autoRedirectOutputMark uint32
@@ -70,6 +71,7 @@ func NewNetworkManager(ctx context.Context, logger logger.ContextLogger, options
 		return nil, E.New("`default_mark` is only supported on linux")
 	}
 	nm := &NetworkManager{
+		ctx:                 ctx,
 		logger:              logger,
 		interfaceFinder:     control.NewDefaultInterfaceFinder(),
 		autoDetectInterface: options.AutoDetectInterface,
@@ -136,6 +138,7 @@ func (r *NetworkManager) Start(stage adapter.StartStage) error {
 	monitor := taskmonitor.New(r.logger, C.StartTimeout)
 	switch stage {
 	case adapter.StartStateInitialize:
+		r.router = service.FromContext[adapter.Router](r.ctx)
 		if r.networkMonitor != nil {
 			monitor.Start("initialize network monitor")
 			err := r.networkMonitor.Start()
@@ -476,6 +479,8 @@ func (r *NetworkManager) ResetNetwork() {
 			listener.InterfaceUpdated()
 		}
 	}
+
+	r.router.ResetNetwork()
 }
 
 func (r *NetworkManager) notifyInterfaceUpdate(defaultInterface *control.Interface, flags int) {

--- a/route/router.go
+++ b/route/router.go
@@ -224,6 +224,5 @@ func (r *Router) NeedFindProcess() bool {
 }
 
 func (r *Router) ResetNetwork() {
-	r.network.ResetNetwork()
 	r.dns.ResetNetwork()
 }

--- a/service/oomkiller/service.go
+++ b/service/oomkiller/service.go
@@ -58,7 +58,7 @@ var (
 type Service struct {
 	boxService.Adapter
 	logger        log.ContextLogger
-	router        adapter.Router
+	network       adapter.NetworkManager
 	memoryLimit   uint64
 	hasTimerMode  bool
 	useAvailable  bool
@@ -70,7 +70,7 @@ func NewService(ctx context.Context, logger log.ContextLogger, tag string, optio
 	s := &Service{
 		Adapter: boxService.NewAdapter(boxConstant.TypeOOMKiller, tag),
 		logger:  logger,
-		router:  service.FromContext[adapter.Router](ctx),
+		network: service.FromContext[adapter.NetworkManager](ctx),
 	}
 
 	if options.MemoryLimit != nil {
@@ -95,7 +95,7 @@ func (s *Service) Start(stage adapter.StartStage) error {
 	}
 
 	if s.hasTimerMode {
-		s.adaptiveTimer = newAdaptiveTimer(s.logger, s.router, s.timerConfig)
+		s.adaptiveTimer = newAdaptiveTimer(s.logger, s.network, s.timerConfig)
 		s.adaptiveTimer.start(false)
 		if s.memoryLimit > 0 {
 			s.logger.Info("started memory monitor with limit: ", s.memoryLimit/(1024*1024), " MiB")
@@ -178,7 +178,7 @@ func goMemoryPressureCallback(status C.ulong) {
 		} else {
 			if isCritical {
 				s.logger.Error("memory pressure: ", level, ", usage: ", usage/(1024*1024), " MiB, resetting network")
-				s.router.ResetNetwork()
+				s.network.ResetNetwork()
 				freeOSMemory = true
 			} else if isWarning {
 				s.logger.Warn("memory pressure: ", level, ", usage: ", usage/(1024*1024), " MiB")

--- a/service/oomkiller/service_timer.go
+++ b/service/oomkiller/service_timer.go
@@ -19,7 +19,7 @@ const (
 
 type adaptiveTimer struct {
 	logger            log.ContextLogger
-	router            adapter.Router
+	network           adapter.NetworkManager
 	memoryLimit       uint64
 	safetyMargin      uint64
 	minInterval       time.Duration
@@ -42,10 +42,10 @@ type timerConfig struct {
 	useAvailable      bool
 }
 
-func newAdaptiveTimer(logger log.ContextLogger, router adapter.Router, config timerConfig) *adaptiveTimer {
+func newAdaptiveTimer(logger log.ContextLogger, network adapter.NetworkManager, config timerConfig) *adaptiveTimer {
 	return &adaptiveTimer{
 		logger:            logger,
-		router:            router,
+		network:           network,
 		memoryLimit:       config.memoryLimit,
 		safetyMargin:      config.safetyMargin,
 		minInterval:       config.minInterval,
@@ -121,7 +121,7 @@ func (t *adaptiveTimer) poll() {
 
 	if triggered {
 		t.logger.Error("memory threshold reached, usage: ", usage/(1024*1024), " MiB, resetting network")
-		t.router.ResetNetwork()
+		t.network.ResetNetwork()
 		runtimeDebug.FreeOSMemory()
 	}
 


### PR DESCRIPTION
Reset the DNS router when the network changes so cached lookups and connections bound to the previous default interface are invalidated.