### PR TITLE
tailscale: fix preferred MagicDNS domain matching

### DIFF
--- a/protocol/tailscale/endpoint.go
+++ b/protocol/tailscale/endpoint.go
@@ -98,6 +98,7 @@ type Endpoint struct {
 	routerCfg     *router.Config
 	dnsCfg        *tsDNS.Config
 	routeDomains  common.TypedValue[map[string]bool]
+	routeSuffixes common.TypedValue[[]string]
 	searchDomains atomic.Bool
 	routePrefixes atomic.Pointer[netipx.IPSet]
 
@@ -790,6 +791,11 @@ func (t *Endpoint) PreferredDomain(domain string) bool {
 	if routeDomains[domain] {
 		return true
 	}
+	for _, suffix := range t.routeSuffixes.Load() {
+		if mDNS.IsSubDomain(suffix, domain) {
+			return true
+		}
+	}
 	return !strings.Contains(domain, ".") && t.searchDomains.Load()
 }
 
@@ -828,13 +834,18 @@ func (t *Endpoint) onReconfig(cfg *wgcfg.Config, routerCfg *router.Config, dnsCf
 	t.dnsCfg = dnsCfg
 
 	routeDomains := make(map[string]bool)
-	for fqdn := range dnsCfg.Routes {
+	for fqdn := range dnsCfg.Hosts {
 		routeDomains[fqdn.WithoutTrailingDot()] = true
 	}
 	for _, fqdn := range dnsCfg.SearchDomains {
 		routeDomains[fqdn.WithoutTrailingDot()] = true
 	}
+	routeSuffixes := make([]string, 0, len(dnsCfg.Routes))
+	for fqdn := range dnsCfg.Routes {
+		routeSuffixes = append(routeSuffixes, fqdn.WithoutTrailingDot())
+	}
 	t.routeDomains.Store(routeDomains)
+	t.routeSuffixes.Store(routeSuffixes)
 	t.searchDomains.Store(len(dnsCfg.SearchDomains) > 0)
 
 	var builder netipx.IPSetBuilder


### PR DESCRIPTION
## Background

A Tailscale endpoint may fail to match a MagicDNS FQDN in a route rule using `preferred_by`.

For example:

```json
{
  "endpoints": [
    {
      "type": "tailscale",
      "tag": "ts-ep"
    }
  ],
  "inbounds": [
    {
      "type": "mixed",
      "tag": "mixed-in",
      "listen": "127.0.0.1",
      "listen_port": 8080
    }
  ],
  "route": {
    "rules": [
      {
        "preferred_by": "ts-ep",
        "action": "route",
        "outbound": "ts-ep"
      }
    ]
  }
}
```

When accessing a MagicDNS host through the HTTP proxy:

```shell
curl --proxy http://127.0.0.1:8080 https://example.tailnet.ts.net/
```

the mixed inbound (also Socks, HTTP, Shadowsocks and etc.) passes the destination domain directly to route matching. No DNS resolution has occurred at this point, so the rule relies on `Endpoint.PreferredDomain`.

The existing implementation only checks `ExportMagicDNSHosts()` when `MagicDNSHostsUnrouted` is true. However, this flag indicates whether MagicDNS host records are covered by DNS routes, rather than whether a domain belongs to MagicDNS. It is false when MagicDNS domain routing is enabled, causing the valid host above to miss the route rule.

The Tailscale DNS transport already handles this correctly. During DNS reconfiguration, it stores the result of [`ExportMagicDNSHosts()`](https://github.com/SagerNet/sing-box/blob/6889e41c605ec4aa7d07b780e84ffa9d76dbcc41/protocol/tailscale/dns_transport.go#L150-L156). Its [`PreferredDomain`](https://github.com/SagerNet/sing-box/blob/6889e41c605ec4aa7d07b780e84ffa9d76dbcc41/protocol/tailscale/dns_transport.go#L265-L279) implementation passes that registry to `lookupHosts` without checking `MagicDNSHostsUnrouted`.

DNS rules using `preferred_by` therefore match the MagicDNS host, while route rules do not because they use the endpoint's separate `PreferredDomain` implementation.