### PR TITLE
Fix FakeIP metadata async save persisting the first snapshot

### DIFF
--- a/experimental/cachefile/cache.go
+++ b/experimental/cachefile/cache.go
@@ -38,21 +38,23 @@ var (
 var _ adapter.CacheFile = (*CacheFile)(nil)
 
 type CacheFile struct {
-	ctx               context.Context
-	path              string
-	cacheID           []byte
-	storeFakeIP       bool
-	storeRDRC         bool
-	rdrcTimeout       time.Duration
-	DB                *bbolt.DB
-	resetAccess       sync.Mutex
-	saveMetadataTimer *time.Timer
-	saveFakeIPAccess  sync.RWMutex
-	saveDomain        map[netip.Addr]string
-	saveAddress4      map[string]netip.Addr
-	saveAddress6      map[string]netip.Addr
-	saveRDRCAccess    sync.RWMutex
-	saveRDRC          map[saveRDRCCacheKey]bool
+	ctx                context.Context
+	path               string
+	cacheID            []byte
+	storeFakeIP        bool
+	storeRDRC          bool
+	rdrcTimeout        time.Duration
+	DB                 *bbolt.DB
+	resetAccess        sync.Mutex
+	saveMetadataAccess sync.Mutex
+	saveMetadata       *adapter.FakeIPMetadata
+	saveMetadataTimer  *time.Timer
+	saveFakeIPAccess   sync.RWMutex
+	saveDomain         map[netip.Addr]string
+	saveAddress4       map[string]netip.Addr
+	saveAddress6       map[string]netip.Addr
+	saveRDRCAccess     sync.RWMutex
+	saveRDRC           map[saveRDRCCacheKey]bool
 }
 
 type saveRDRCCacheKey struct {

--- a/experimental/cachefile/fakeip.go
+++ b/experimental/cachefile/fakeip.go
@@ -59,9 +59,17 @@ func (c *CacheFile) FakeIPSaveMetadata(metadata *adapter.FakeIPMetadata) error {
 }
 
 func (c *CacheFile) FakeIPSaveMetadataAsync(metadata *adapter.FakeIPMetadata) {
+	c.saveMetadataAccess.Lock()
+	defer c.saveMetadataAccess.Unlock()
+	c.saveMetadata = metadata
 	if c.saveMetadataTimer == nil {
 		c.saveMetadataTimer = time.AfterFunc(C.FakeIPMetadataSaveInterval, func() {
-			_ = c.FakeIPSaveMetadata(metadata)
+			c.saveMetadataAccess.Lock()
+			savedMetadata := c.saveMetadata
+			c.saveMetadataAccess.Unlock()
+			if savedMetadata != nil {
+				_ = c.FakeIPSaveMetadata(savedMetadata)
+			}
 		})
 	} else {
 		c.saveMetadataTimer.Reset(C.FakeIPMetadataSaveInterval)


### PR DESCRIPTION
### Problem

`FakeIPSaveMetadataAsync` creates the save timer on the first call and only resets it afterwards:

```go
func (c *CacheFile) FakeIPSaveMetadataAsync(metadata *adapter.FakeIPMetadata) {
	if c.saveMetadataTimer == nil {
		c.saveMetadataTimer = time.AfterFunc(C.FakeIPMetadataSaveInterval, func() {
			_ = c.FakeIPSaveMetadata(metadata)   // captured on the first call only
		})
	} else {
		c.saveMetadataTimer.Reset(C.FakeIPMetadataSaveInterval)  // reschedules, never updates the data
	}
}
```

`(*fakeip.Store).Create` builds a fresh `FakeIPMetadata` carrying the current counter on every allocation and hands it to this method, so every value after the first one is discarded. Whenever the timer fires it writes back the counter as of the process's **first** allocation.

### Impact

`(*fakeip.Store).Close` writes the accurate final value, so the defect is invisible on a clean shutdown. When a process does not get to run `Close` — killed forcefully, or terminated in a way that skips signal handling — the next start reads a counter rewound to the first allocation point while the address/domain mapping in `fakeip_address` / `fakeip_domain4` / `fakeip_domain6` survives intact.

The store then re-hands-out addresses that are still mapped to earlier domains. `FakeIPStore` overwrites the mapping for the reused address, but clients holding the previous answer keep sending to it, and `route.go` reverse-maps that address to the **new** domain — so traffic is silently sent to a different destination until the client's cached answer expires. With the default TTL that window is up to 10 minutes, and OS-level DNS flushes do not reach caches inside applications.

This also explains a symptom that looks unrelated: the persisted counter advances by roughly one slot per run while each run consumes many, so a long-used profile keeps re-issuing the same low addresses while higher ones become permanently stale.

### Change

Keep the newest metadata in a field guarded by a mutex and have the timer read that field. A save without a clean shutdown is then at most `FakeIPMetadataSaveInterval` behind, instead of losing the whole session.

The mutex is inside `CacheFile` rather than relying on the caller: `Create` happens to hold `addressAccess` across the call today, but `CacheFile` implements the exported `adapter.CacheFile` interface and the sibling async savers (`saveFakeIPAccess`, `saveRDRCAccess`) already guard their own state.

### Test

`TestFakeIPSaveMetadataAsyncPersistsLatest` performs three successive async saves and asserts the last one reaches the disk.

- before this change: `persisted Inet4Current = 198.18.0.2, want 198.18.0.42` — FAIL
- after: PASS, also under `-race`

It waits for `FakeIPMetadataSaveInterval`, so it is skipped under `-short`.

### Second commit

`Stop the FakeIP metadata save timer on cache file close` is a lifecycle cleanup, not a bug fix, and it deliberately carries no test. Writing after `Close` is currently harmless — bbolt returns `ErrDatabaseNotOpen`, the error is discarded, and I verified the cache file is left untouched (same size and mtime, and the `recover` path in `batch` is not reached, so `resetDB` does not run). It is worth doing only so the timer does not outlive the instance it writes through, and so an in-flight save cannot race with the database being closed.

**Please drop that commit if you would rather keep `Close` minimal** — the first commit stands on its own.