### PR TITLE
docs: document endpoint-independent NAT deprecation

### DIFF
--- a/docs/clients/android/features.md
+++ b/docs/clients/android/features.md
@@ -25,7 +25,6 @@ SFA provides an unprivileged TUN implementation through Android VpnService.
 | `inet6_route_address`         | :material-check: | /                  |
 | `inet4_route_exclude_address` | :material-check: | /                  |
 | `inet6_route_exclude_address` | :material-check: | /                  |
-| `endpoint_independent_nat`    | :material-check: | /                  |
 | `stack`                       | :material-check: | /                  |
 | `include_interface`           | :material-close: | No permission      |
 | `exclude_interface`           | :material-close: | No permission      |

--- a/docs/clients/apple/features.md
+++ b/docs/clients/apple/features.md
@@ -27,7 +27,6 @@ SFI/SFM/SFT provides an unprivileged TUN implementation through NetworkExtension
 | `inet6_route_address`         | :material-check:  | /                 |
 | `inet4_route_exclude_address` | :material-check:  | /                 |
 | `inet6_route_exclude_address` | :material-check:  | /                 |
-| `endpoint_independent_nat`    | :material-check:  | /                 |
 | `stack`                       | :material-check:  | /                 |
 | `include_interface`           | :material-close:️ | Not implemented   |
 | `exclude_interface`           | :material-close:️ | Not implemented   |

--- a/docs/configuration/inbound/tun.md
+++ b/docs/configuration/inbound/tun.md
@@ -550,13 +550,10 @@ Exclude custom routes when `auto_route` is enabled.
 
 #### endpoint_independent_nat
 
-!!! info ""
+This option has had no effect since sing-box 1.11.0 and can be removed from the configuration.
 
-    This item is only available on the gvisor stack, other stacks are endpoint-independent NAT by default.
-
-Enable endpoint-independent NAT.
-
-Performance may degrade slightly, so it is not recommended to enable on when it is not needed.
+Since sing-box 1.14.0, use [UDP NAT fields](/configuration/shared/udp-nat/)
+to customize the mapping and filtering behavior.
 
 #### stack
 

--- a/docs/configuration/inbound/tun.zh.md
+++ b/docs/configuration/inbound/tun.zh.md
@@ -534,9 +534,9 @@ sing-box DNS 模块，等价于一条
 
 #### endpoint_independent_nat
 
-启用独立于端点的 NAT。
+此选项自 sing-box 1.11.0 起不再生效，可从配置中移除。
 
-性能可能会略有下降，所以不建议在不需要的时候开启。
+自 sing-box 1.14.0 起，可使用 [UDP NAT 字段](/zh/configuration/shared/udp-nat/)自定义映射和过滤行为。
 
 #### stack
 


### PR DESCRIPTION
Document that `endpoint_independent_nat` has no effect since sing-box 1.11.0.

Add migration guidance and remove the obsolete option from Android and Apple feature tables.

Closes #4432
